### PR TITLE
Comparison chain

### DIFF
--- a/src/bit_vec/fast_rs_vec/mod.rs
+++ b/src/bit_vec/fast_rs_vec/mod.rs
@@ -550,6 +550,7 @@ impl RsVec {
     /// memory or panic).
     /// If the length of the query is larger than 64, the behavior is undefined.
     #[must_use]
+    #[allow(clippy::comparison_chain)]
     pub fn get_bits_unchecked(&self, pos: usize, len: usize) -> u64 {
         debug_assert!(len <= WORD_SIZE);
         let partial_word = self.data[pos / WORD_SIZE] >> (pos % WORD_SIZE);

--- a/src/bit_vec/fast_rs_vec/mod.rs
+++ b/src/bit_vec/fast_rs_vec/mod.rs
@@ -550,7 +550,7 @@ impl RsVec {
     /// memory or panic).
     /// If the length of the query is larger than 64, the behavior is undefined.
     #[must_use]
-    #[allow(clippy::comparison_chain)]
+    #[allow(clippy::comparison_chain)] // rust-clippy #5354
     pub fn get_bits_unchecked(&self, pos: usize, len: usize) -> u64 {
         debug_assert!(len <= WORD_SIZE);
         let partial_word = self.data[pos / WORD_SIZE] >> (pos % WORD_SIZE);

--- a/src/bit_vec/mod.rs
+++ b/src/bit_vec/mod.rs
@@ -271,7 +271,7 @@ impl BitVec {
     /// If the length of the query is larger than 64, the behavior is undefined.
     #[must_use]
     #[allow(clippy::inline_always)]
-    #[allow(clippy::comparison_chain)]
+    #[allow(clippy::comparison_chain)] // rust-clippy #5354
     #[inline(always)] // inline to gain loop optimization and pipeline advantages for elias fano
     pub fn get_bits_unchecked(&self, pos: usize, len: usize) -> u64 {
         debug_assert!(len <= WORD_SIZE);

--- a/src/bit_vec/mod.rs
+++ b/src/bit_vec/mod.rs
@@ -271,6 +271,7 @@ impl BitVec {
     /// If the length of the query is larger than 64, the behavior is undefined.
     #[must_use]
     #[allow(clippy::inline_always)]
+    #[allow(clippy::comparison_chain)]
     #[inline(always)] // inline to gain loop optimization and pipeline advantages for elias fano
     pub fn get_bits_unchecked(&self, pos: usize, len: usize) -> u64 {
         debug_assert!(len <= WORD_SIZE);

--- a/src/elias_fano/mod.rs
+++ b/src/elias_fano/mod.rs
@@ -195,6 +195,7 @@ impl EliasFanoVec {
     /// Use `predecessor` instead if the query might be out of bounds.
     #[must_use]
     #[allow(clippy::cast_possible_truncation)]
+    #[allow(clippy::comparison_chain)]
     pub fn predecessor_unchecked(&self, n: u64) -> u64 {
         if n > self.universe_max {
             return self.get_unchecked(self.len() - 1);
@@ -332,6 +333,7 @@ impl EliasFanoVec {
     /// Use `successor` instead if the query might be out of bounds.
     #[must_use]
     #[allow(clippy::cast_possible_truncation)]
+    #[allow(clippy::comparison_chain)]
     pub fn successor_unchecked(&self, n: u64) -> u64 {
         if n < self.universe_zero {
             return self.get_unchecked(0);

--- a/src/elias_fano/mod.rs
+++ b/src/elias_fano/mod.rs
@@ -195,7 +195,7 @@ impl EliasFanoVec {
     /// Use `predecessor` instead if the query might be out of bounds.
     #[must_use]
     #[allow(clippy::cast_possible_truncation)]
-    #[allow(clippy::comparison_chain)]
+    #[allow(clippy::comparison_chain)] // rust-clippy #5354
     pub fn predecessor_unchecked(&self, n: u64) -> u64 {
         if n > self.universe_max {
             return self.get_unchecked(self.len() - 1);
@@ -333,7 +333,7 @@ impl EliasFanoVec {
     /// Use `successor` instead if the query might be out of bounds.
     #[must_use]
     #[allow(clippy::cast_possible_truncation)]
-    #[allow(clippy::comparison_chain)]
+    #[allow(clippy::comparison_chain)] // rust-clippy #5354
     pub fn successor_unchecked(&self, n: u64) -> u64 {
         if n < self.universe_zero {
             return self.get_unchecked(0);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,9 +16,6 @@
 //! in the [Github repository](https://github.com/Cydhra/vers). At the time of writing,
 //! this crate is the fastest implementation of all data structures except for one implementation
 //! of rank on bit-vectors (which pays for its speed with a missing select implementation).
-//! This crate uses multiple if chains. While using match and cmp might be more idiomatic and exhaustive, 
-//! currently the complier might not inline cmp calls and if chains can be faster. See rust-lang #5354
-//! 
 //!
 //! # Intrinsics
 //! This crate uses compiler intrinsics for bit-manipulation. The intrinsics are supported by
@@ -35,9 +32,6 @@
 //! bit-manipulation. The intrinsics cannot fail with the provided inputs (provided they are
 //! supported by the target machine), so even if they were to be implemented incorrectly, no
 //! memory unsafety can occur (only incorrect results).
-
-// If and when match/cmp becomes faster, remove this
-#![allow(clippy::comparison_chain)]
 
 pub use crate::elias_fano::EliasFanoVec;
 pub use bit_vec::fast_rs_vec::RsVec;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,9 @@
 //! in the [Github repository](https://github.com/Cydhra/vers). At the time of writing,
 //! this crate is the fastest implementation of all data structures except for one implementation
 //! of rank on bit-vectors (which pays for its speed with a missing select implementation).
+//! This crate uses multiple if chains. While using match and cmp might be more idiomatic and exhaustive, 
+//! currently the complier might not inline cmp calls and if chains can be faster. See rust-lang #5354
+//! 
 //!
 //! # Intrinsics
 //! This crate uses compiler intrinsics for bit-manipulation. The intrinsics are supported by
@@ -32,6 +35,9 @@
 //! bit-manipulation. The intrinsics cannot fail with the provided inputs (provided they are
 //! supported by the target machine), so even if they were to be implemented incorrectly, no
 //! memory unsafety can occur (only incorrect results).
+
+// If and when match/cmp becomes faster, remove this
+#![allow(clippy::comparison_chain)]
 
 pub use crate::elias_fano::EliasFanoVec;
 pub use bit_vec::fast_rs_vec::RsVec;


### PR DESCRIPTION
Hi! thanks for your work.

I've been looking into the code and it seems some default lints comeup with warning.

As for the `if chain` I assume that this has already been tested and found that the current if chain is faster.

Although the expressiveness and safety(exhaustive matching) of `match` is favorable, due to https://github.com/rust-lang/rust-clippy/issues/5354 if chain is often used in performance critical code like this.

I thought maybe suppressing the lints like this and documenting why could be helpful since it reduces warnings on the default clippy settings.