### PR TITLE
last of Clippy fixes

### DIFF
--- a/src/elias_fano/mod.rs
+++ b/src/elias_fano/mod.rs
@@ -76,7 +76,7 @@ impl EliasFanoVec {
     #[must_use]
     #[allow(clippy::cast_possible_truncation)]
     pub fn from_slice(data: &[u64]) -> Self {
-        if data.len() == 0 {
+        if data.is_empty() {
             return Self {
                 upper_vec: RsVec::from_bit_vec(BitVec::new()),
                 lower_vec: BitVec::new(),

--- a/src/rmq/binary_rmq/mod.rs
+++ b/src/rmq/binary_rmq/mod.rs
@@ -48,7 +48,7 @@ impl BinaryRmq {
         // but saves us a large amount of page faults for big vectors, when compared to having a
         // two-dimensional array with dynamic length in the second dimension.
         let len = data.len();
-        assert!(len <= u32::MAX as usize, "input too large for binary rmq");
+        assert!(u32::try_from(len).is_ok(), "input too large for binary rmq");
 
         let row_length = len.next_power_of_two().trailing_zeros() as usize + 1;
         let mut results = vec![0u32; len * row_length];

--- a/src/rmq/fast_rmq/mod.rs
+++ b/src/rmq/fast_rmq/mod.rs
@@ -24,7 +24,7 @@ impl SmallBitVector {
     #[allow(clippy::cast_sign_loss)]
     fn rank0(&self, i: usize) -> usize {
         debug_assert!(i <= 128);
-        let mask = ![(-1i128 << (i & 127)), 0][(i == 128) as usize] as u128;
+        let mask = ![(-1i128 << (i & 127)), 0][usize::from(i == 128)] as u128;
         (!self.0 & mask).count_ones() as usize
     }
 


### PR DESCRIPTION
This PR shores up the last of the default `cargo clippy` warnings.

To be frank, it goes one commit further by changing some conversions into safe conversions that are arguably easier to read and more idiomatic (this part would be subjective and I'm not going to defend it if anyone disagrees)

I added the second commit because I didn't want a oneline diff to be a whole PR, but if it is deemed unnecessary or harmful I can easily revert it.