### PR TITLE
fix bitset iterator bench when simd is disabled

### DIFF
--- a/benches/select_iter.rs
+++ b/benches/select_iter.rs
@@ -48,6 +48,14 @@ fn bench_select_iter(b: &mut Criterion) {
             })
         });
 
+        #[cfg(all(
+            feature = "simd",
+            target_arch = "x86_64",
+            target_feature = "avx",
+            target_feature = "avx2",
+            target_feature = "avx512f",
+            target_feature = "avx512bw",
+        ))]
         group.bench_with_input(BenchmarkId::new("bitset iterator", l), &l, |b, _| {
             b.iter_custom(|iters| {
                 let mut time = Duration::new(0, 0);


### PR DESCRIPTION
I noticed that the benchmark was failing on my M1 Mac.
One of the benches relies on the SIMD features, so I just enabled it conditionally like the other stuff.