### PR TITLE
fix small typo in the `SelectSuperBlockDescriptor` documentation

### DIFF
--- a/src/bit_vec/fast_rs_vec/mod.rs
+++ b/src/bit_vec/fast_rs_vec/mod.rs
@@ -58,7 +58,7 @@ struct SuperBlockDescriptor {
 
 /// Meta-data for the select query. Each entry i in the select vector contains the indices to find
 /// the i * `SELECT_BLOCK_SIZE`'th 0- and 1-bit in the bitvector. Those indices may be very far apart.
-/// The indices do not point into the bit-vector, but into the select-block vector.
+/// The indices do not point into the bit-vector, but into the super-block vector.
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 struct SelectSuperBlockDescriptor {


### PR DESCRIPTION
Fix the small [typo mentioned before](https://github.com/Cydhra/vers/issues/5#issuecomment-2323250984).