### PR TITLE
Dev bp clippy

### DIFF
--- a/benches/sparse_equals.rs
+++ b/benches/sparse_equals.rs
@@ -44,7 +44,7 @@ fn bench(b: &mut Criterion<TimeDiff>) {
 
         for fill_factor in FILL_FACTORS {
             group.bench_with_input(
-                BenchmarkId::new("sparse overhead equal", &fill_factor),
+                BenchmarkId::new("sparse overhead equal", fill_factor),
                 &fill_factor,
                 |b, _| {
                     b.iter_custom(|iters| {
@@ -69,7 +69,7 @@ fn bench(b: &mut Criterion<TimeDiff>) {
             );
 
             group.bench_with_input(
-                BenchmarkId::new("sparse overhead unequal", &fill_factor),
+                BenchmarkId::new("sparse overhead unequal", fill_factor),
                 &fill_factor,
                 |b, _| {
                     b.iter_custom(|iters| {

--- a/src/bit_vec/fast_rs_vec/tests.rs
+++ b/src/bit_vec/fast_rs_vec/tests.rs
@@ -45,14 +45,14 @@ fn test_random_data_rank() {
         let data_index = rnd_index / WORD_SIZE;
         let bit_index = rnd_index % WORD_SIZE;
 
-        for i in 0..data_index {
-            expected_rank1 += data[i].count_ones() as usize;
-            expected_rank0 += data[i].count_zeros() as usize;
+        for v in data.iter().take(data_index) {
+            expected_rank1 += v.count_ones() as usize;
+            expected_rank0 += v.count_zeros() as usize;
         }
 
         if bit_index > 0 {
-            expected_rank1 += (data[data_index] & (1 << bit_index) - 1).count_ones() as usize;
-            expected_rank0 += (!data[data_index] & (1 << bit_index) - 1).count_ones() as usize;
+            expected_rank1 += (data[data_index] & ((1 << bit_index) - 1)).count_ones() as usize;
+            expected_rank0 += (!data[data_index] & ((1 << bit_index) - 1)).count_ones() as usize;
         }
 
         assert_eq!(actual_rank1, expected_rank1);
@@ -503,14 +503,14 @@ fn test_custom_iter_behavior() {
     assert!(iter.advance_by(6).is_err());
     assert!(iter.advance_back_by(5).is_ok());
 
-    assert_eq!(rs.iter().skip(2).next(), Some(0));
+    assert_eq!(rs.iter().nth(2), Some(0));
     assert_eq!(rs.iter().count(), 10);
     assert_eq!(rs.iter().skip(2).count(), 8);
     assert_eq!(rs.iter().last(), Some(0));
     assert_eq!(rs.iter().nth(3), Some(1));
     assert_eq!(rs.iter().nth(12), None);
 
-    assert_eq!(rs.clone().into_iter().skip(2).next(), Some(0));
+    assert_eq!(rs.clone().into_iter().nth(2), Some(0));
     assert_eq!(rs.clone().into_iter().count(), 10);
     assert_eq!(rs.clone().into_iter().skip(2).count(), 8);
     assert_eq!(rs.clone().into_iter().last(), Some(0));
@@ -1093,21 +1093,21 @@ fn test_sparse_equals() {
     let rs1 = RsVec::from_bit_vec(bv.clone());
     let rs2 = RsVec::from_bit_vec(bv.clone());
 
-    assert_eq!(rs1.sparse_equals::<false>(&rs2), true);
-    assert_eq!(rs1.sparse_equals::<true>(&rs2), true);
+    assert!(rs1.sparse_equals::<false>(&rs2));
+    assert!(rs1.sparse_equals::<true>(&rs2));
 
     bv.flip_bit(3);
     let rs2 = RsVec::from_bit_vec(bv.clone());
 
-    assert_eq!(rs1.sparse_equals::<false>(&rs2), false);
-    assert_eq!(rs1.sparse_equals::<true>(&rs2), false);
+    assert!(!rs1.sparse_equals::<false>(&rs2));
+    assert!(!rs1.sparse_equals::<true>(&rs2));
 
     bv.flip_bit(3);
     bv.flip_bit(2 * SUPER_BLOCK_SIZE - 1);
     let rs1 = RsVec::from_bit_vec(bv.clone());
 
-    assert_eq!(rs1.sparse_equals::<false>(&rs2), false);
-    assert_eq!(rs1.sparse_equals::<true>(&rs2), false);
+    assert!(!rs1.sparse_equals::<false>(&rs2));
+    assert!(!rs1.sparse_equals::<true>(&rs2));
 }
 
 #[test]
@@ -1137,18 +1137,18 @@ fn test_full_equals() {
     let rs1 = RsVec::from_bit_vec(bv.clone());
     let rs2 = RsVec::from_bit_vec(bv.clone());
 
-    assert_eq!(rs1.full_equals(&rs2), true);
+    assert!(rs1.full_equals(&rs2));
 
     bv.flip_bit(3);
     let rs2 = RsVec::from_bit_vec(bv.clone());
 
-    assert_eq!(rs1.full_equals(&rs2), false);
+    assert!(!rs1.full_equals(&rs2));
 
     bv.flip_bit(3);
     bv.flip_bit(2 * SUPER_BLOCK_SIZE - 1);
     let rs1 = RsVec::from_bit_vec(bv.clone());
 
-    assert_eq!(rs1.full_equals(&rs2), false);
+    assert!(!rs1.full_equals(&rs2));
 }
 
 // fuzzing test for iter1 and iter0 as last ditch fail-safe
@@ -1332,7 +1332,7 @@ fn test_iter1_regression_i8() {
     let mut bv = BitVec::from_zeros(8193);
 
     for idx in &input_on_bits {
-        bv.set(*idx as usize, 1).unwrap();
+        bv.set(*idx, 1).unwrap();
     }
 
     let bv = RsVec::from_bit_vec(bv);

--- a/src/bit_vec/mod.rs
+++ b/src/bit_vec/mod.rs
@@ -533,7 +533,7 @@ impl BitVec {
             return;
         }
 
-        let new_limb_count = (self.len - n + WORD_SIZE - 1) / WORD_SIZE;
+        let new_limb_count = (self.len - n).div_ceil(WORD_SIZE);
 
         // cut off limbs that we no longer need
         if new_limb_count < self.data.len() {

--- a/src/bit_vec/tests.rs
+++ b/src/bit_vec/tests.rs
@@ -213,14 +213,18 @@ fn test_custom_iter_behavior() {
     assert!(iter.advance_by(6).is_err());
     assert!(iter.advance_back_by(5).is_ok());
 
-    assert_eq!(bv.iter().nth(2), Some(0));
+    #[allow(clippy::iter_skip_next)]
+    let next = bv.iter().skip(2).next(); // explicit test for skip()
+    assert_eq!(next, Some(0));
     assert_eq!(bv.iter().count(), 10);
     assert_eq!(bv.iter().skip(2).count(), 8);
     assert_eq!(bv.iter().last(), Some(0));
     assert_eq!(bv.iter().nth(3), Some(1));
     assert_eq!(bv.iter().nth(12), None);
 
-    assert_eq!(bv.clone().into_iter().nth(2), Some(0));
+    #[allow(clippy::iter_skip_next)]
+    let next = bv.clone().into_iter().skip(2).next(); // explicit test for skip()
+    assert_eq!(next, Some(0));
     assert_eq!(bv.clone().into_iter().count(), 10);
     assert_eq!(bv.clone().into_iter().skip(2).count(), 8);
     assert_eq!(bv.clone().into_iter().last(), Some(0));

--- a/src/bit_vec/tests.rs
+++ b/src/bit_vec/tests.rs
@@ -213,14 +213,14 @@ fn test_custom_iter_behavior() {
     assert!(iter.advance_by(6).is_err());
     assert!(iter.advance_back_by(5).is_ok());
 
-    assert_eq!(bv.iter().skip(2).next(), Some(0));
+    assert_eq!(bv.iter().nth(2), Some(0));
     assert_eq!(bv.iter().count(), 10);
     assert_eq!(bv.iter().skip(2).count(), 8);
     assert_eq!(bv.iter().last(), Some(0));
     assert_eq!(bv.iter().nth(3), Some(1));
     assert_eq!(bv.iter().nth(12), None);
 
-    assert_eq!(bv.clone().into_iter().skip(2).next(), Some(0));
+    assert_eq!(bv.clone().into_iter().nth(2), Some(0));
     assert_eq!(bv.clone().into_iter().count(), 10);
     assert_eq!(bv.clone().into_iter().skip(2).count(), 8);
     assert_eq!(bv.clone().into_iter().last(), Some(0));

--- a/src/elias_fano/tests.rs
+++ b/src/elias_fano/tests.rs
@@ -231,7 +231,9 @@ fn test_iter() {
 #[test]
 fn test_custom_iter_behavior() {
     let ef = EliasFanoVec::from_slice(&[0, 1, 2, 3, 4, 5, 6, 7, 8]);
-    assert_eq!(ef.iter().nth(2), Some(2));
+    #[allow(clippy::iter_skip_next)]
+    let next = ef.iter().skip(2).next(); // explicit test for skip()
+    assert_eq!(next, Some(2));
     assert_eq!(ef.iter().count(), 9);
     assert_eq!(ef.iter().skip(2).count(), 7);
     assert_eq!(ef.iter().last(), Some(8));

--- a/src/elias_fano/tests.rs
+++ b/src/elias_fano/tests.rs
@@ -252,7 +252,9 @@ fn test_custom_iter_behavior() {
     assert!(iter.advance_by(6).is_err());
     assert!(iter.advance_back_by(4).is_ok());
 
-    assert_eq!(ef.clone().into_iter().nth(2), Some(2));
+    #[allow(clippy::iter_skip_next)]
+    let next = ef.clone().into_iter().skip(2).next(); // explicit test for skip()
+    assert_eq!(next, Some(2));
     assert_eq!(ef.clone().into_iter().count(), 9);
     assert_eq!(ef.clone().into_iter().skip(2).count(), 7);
     assert_eq!(ef.clone().into_iter().last(), Some(8));

--- a/src/trees/bp/builder.rs
+++ b/src/trees/bp/builder.rs
@@ -1,6 +1,6 @@
-use crate::BitVec;
 use crate::trees::bp::BpTree;
 use crate::trees::DfsTreeBuilder;
+use crate::BitVec;
 
 /// A builder for [`BpTrees`] using depth-first traversal of the tree. See the documentation of
 /// [`DfsTreeBuilder`].
@@ -26,6 +26,12 @@ impl<const BLOCK_SIZE: usize> BpDfsBuilder<BLOCK_SIZE> {
             excess: 0,
             bit_vec: BitVec::with_capacity((capacity * 2) as usize),
         }
+    }
+}
+
+impl<const BLOCK_SIZE: usize> Default for BpDfsBuilder<BLOCK_SIZE> {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/src/trees/bp/tests.rs
+++ b/src/trees/bp/tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::BitVec;
-use rand::{RngCore, SeedableRng};
 use rand::rngs::StdRng;
+use rand::{RngCore, SeedableRng};
 
 #[test]
 fn test_fwd_search() {
@@ -99,7 +99,7 @@ fn test_fwd_unbalanced_expression() {
 
 #[test]
 fn test_fwd_block_boundary() {
-    let bv = BitVec::from_bits(&[1, 1, 0, 1, 0, 0,]);
+    let bv = BitVec::from_bits(&[1, 1, 0, 1, 0, 0]);
     let tree = BpTree::<4>::from_bit_vector(bv);
 
     // test if a query returns the correct result if the result is the first bit in a block
@@ -113,7 +113,7 @@ fn test_fwd_block_boundary() {
 
 #[test]
 fn test_fwd_negative_block() {
-    let bv = BitVec::from_bits(&[1, 1, 1, 1, 0, 0, 0, 0,]);
+    let bv = BitVec::from_bits(&[1, 1, 1, 1, 0, 0, 0, 0]);
     let tree = BpTree::<2>::from_bit_vector(bv);
 
     // regression: test if a query correctly returns none (instead of crashing) if the following
@@ -285,7 +285,7 @@ fn test_bwd_illegal_queries() {
 fn test_bwd_left_block_boundary() {
     // test if a query returns the correct result if the result is the first bit after
     // a block boundary (the left-most one even for backward search)
-    let bv = BitVec::from_bits(&[1, 1, 0, 1, 0, 0,]);
+    let bv = BitVec::from_bits(&[1, 1, 0, 1, 0, 0]);
     let tree = BpTree::<4>::from_bit_vector(bv);
 
     assert_eq!(tree.bwd_search(5, 0), Some(3));
@@ -307,9 +307,7 @@ fn test_bwd_right_block_boundary() {
 
 #[test]
 fn test_bwd_block_traversal() {
-    let bv = BitVec::from_bits(&[
-        1, 1, 1, 1, 0,
-    ]);
+    let bv = BitVec::from_bits(&[1, 1, 1, 1, 0]);
     let tree = BpTree::<4>::from_bit_vector(bv);
 
     // if we request excess 0 backwards at a block boundary
@@ -346,13 +344,16 @@ fn test_bwd_fuzzy() {
         }
     }
 
-
     let bp = BpTree::<128>::from_bit_vector(bit_vec);
 
     // test any query from valid nodes with the given relative excess values
     for relative_excess in [-3, -2, -1, 0, 1, 2, 3] {
         for node_handle in bp.vec.iter0() {
-            let absolute_excess = if node_handle == 0 { 0 } else { bp.excess(node_handle - 1) + relative_excess };
+            let absolute_excess = if node_handle == 0 {
+                0
+            } else {
+                bp.excess(node_handle - 1) + relative_excess
+            };
             let expected = excess_values[..node_handle]
                 .iter()
                 .rposition(|&excess| excess as i64 == absolute_excess);
@@ -525,13 +526,7 @@ fn test_is_leaf() {
     let bv = BitVec::from_bits(&bits);
     let leaves = bits[..]
         .windows(2)
-        .map(|window| {
-            if window[0] == 1 && window[1] == 0 {
-                true
-            } else {
-                false
-            }
-        })
+        .map(|window| window[0] == 1 && window[1] == 0)
         .collect::<Vec<_>>();
     let tree = BpTree::<8>::from_bit_vector(bv.clone());
 

--- a/src/wavelet/mod.rs
+++ b/src/wavelet/mod.rs
@@ -94,8 +94,8 @@ impl WaveletMatrix {
 
         for (level, data) in data.iter_mut().enumerate() {
             let mut total_zeros = 0;
-            for i in 0..num_elements {
-                if bit_lookup(permutation[i], element_len - level - 1) == 0 {
+            for (i, p) in permutation.iter().enumerate().take(num_elements) {
+                if bit_lookup(*p, element_len - level - 1) == 0 {
                     total_zeros += 1;
                 } else {
                     data.set(i, 1).unwrap();
@@ -107,12 +107,12 @@ impl WaveletMatrix {
             if level < element_len - 1 {
                 let mut zero_boundary = 0;
                 let mut one_boundary = total_zeros;
-                for i in 0..num_elements {
+                for (i, p) in permutation.iter().enumerate().take(num_elements) {
                     if data.get_unchecked(i) == 0 {
-                        next_permutation[zero_boundary] = permutation[i];
+                        next_permutation[zero_boundary] = *p;
                         zero_boundary += 1;
                     } else {
-                        next_permutation[one_boundary] = permutation[i];
+                        next_permutation[one_boundary] = *p;
                         one_boundary += 1;
                     }
                 }
@@ -346,7 +346,7 @@ impl WaveletMatrix {
         let mut value = BitVec::from_zeros(self.bits_per_element());
         let mut level = self.bits_per_element() - 1;
         self.reconstruct_value_unchecked(i, |bit| {
-            value.set_unchecked(level as usize, bit);
+            value.set_unchecked(level, bit);
             level = level.saturating_sub(1);
         });
         value

--- a/src/wavelet/mod.rs
+++ b/src/wavelet/mod.rs
@@ -94,7 +94,7 @@ impl WaveletMatrix {
 
         for (level, data) in data.iter_mut().enumerate() {
             let mut total_zeros = 0;
-            for (i, p) in permutation.iter().enumerate().take(num_elements) {
+            for (i, p) in permutation.iter().enumerate() {
                 if bit_lookup(*p, element_len - level - 1) == 0 {
                     total_zeros += 1;
                 } else {
@@ -107,7 +107,7 @@ impl WaveletMatrix {
             if level < element_len - 1 {
                 let mut zero_boundary = 0;
                 let mut one_boundary = total_zeros;
-                for (i, p) in permutation.iter().enumerate().take(num_elements) {
+                for (i, p) in permutation.iter().enumerate() {
                     if data.get_unchecked(i) == 0 {
                         next_permutation[zero_boundary] = *p;
                         zero_boundary += 1;

--- a/src/wavelet/tests.rs
+++ b/src/wavelet/tests.rs
@@ -696,14 +696,14 @@ fn test_wavelet_iter_randomized() {
         let wavelet = WaveletMatrix::from_bit_vec(&BitVec::pack_sequence_u8(&data, 8), 8);
 
         let mut iter = wavelet.iter();
-        for i in 0..data.len() {
-            assert_eq!(iter.next(), Some(BitVec::pack_sequence_u8(&[data[i]], 8)));
+        for v in &data {
+            assert_eq!(iter.next(), Some(BitVec::pack_sequence_u8(&[*v], 8)));
         }
         assert_eq!(iter.next(), None);
 
         let mut iter = wavelet.iter_u64().unwrap();
-        for i in 0..data.len() {
-            assert_eq!(iter.next(), Some(data[i] as u64));
+        for v in &data {
+            assert_eq!(iter.next(), Some(*v as u64));
         }
         assert_eq!(iter.next(), None);
     }

--- a/src/wavelet/tests.rs
+++ b/src/wavelet/tests.rs
@@ -39,10 +39,10 @@ fn test_wavelet_encoding_randomized() {
 
         assert_eq!(wavelet.len(), data.len());
 
-        for i in 0..data.len() {
-            assert_eq!(wavelet.get_u64_unchecked(i), data[i] as u64);
-            assert_eq!(wavelet_from_slice.get_u64_unchecked(i), data[i] as u64);
-            assert_eq!(wavelet_prefix_counting.get_u64_unchecked(i), data[i] as u64);
+        for (i, v) in data.iter().enumerate() {
+            assert_eq!(wavelet.get_u64_unchecked(i), *v as u64);
+            assert_eq!(wavelet_from_slice.get_u64_unchecked(i), *v as u64);
+            assert_eq!(wavelet_prefix_counting.get_u64_unchecked(i), *v as u64);
         }
     }
 }
@@ -137,9 +137,9 @@ fn test_rank_randomized() {
     for symbol in symbols {
         let symbol_bit_vec = BitVec::pack_sequence_u8(&[symbol], 8);
         let mut rank = 0;
-        for i in 0..data.len() {
+        for (i, v) in data.iter().enumerate() {
             assert_eq!(wavelet.rank_unchecked(i, &symbol_bit_vec), rank);
-            if data[i] == symbol {
+            if *v == symbol {
                 rank += 1;
             }
         }
@@ -228,12 +228,12 @@ fn test_quantile() {
 
     sequence.sort();
 
-    for i in 0..sequence.len() {
+    for (i, v) in sequence.iter().enumerate() {
         assert_eq!(
             wavelet.quantile(0..10, i),
-            Some(BitVec::pack_sequence_u8(&[sequence[i] as u8], 4))
+            Some(BitVec::pack_sequence_u8(&[*v as u8], 4))
         );
-        assert_eq!(wavelet.quantile_u64(0..10, i), Some(sequence[i]));
+        assert_eq!(wavelet.quantile_u64(0..10, i), Some(*v));
     }
 
     assert_eq!(wavelet.quantile(0..10, 10), None);
@@ -279,7 +279,7 @@ fn test_quantile_randomized() {
             rng.gen_range(range.clone()) - range.start
         };
 
-        let mut range_data = data[range.clone()].iter().copied().collect::<Vec<u8>>();
+        let mut range_data = data[range.clone()].to_vec();
         range_data.sort_unstable();
 
         assert_eq!(


### PR DESCRIPTION
Here's a draft PR applying suggested clippy changes to the dev_bp branch to make `cargo clippy` produce no output and besides that I tried to follow clippy suggestions in tests and benches.

Many of the clippy changes are in tests. A lot of them have to do with changing manual indexing to using iterators, or not using `vec!` for sample data.

In main code:

I noticed that unfortunately there are some spurious diffs due to whitespace changes - I only use the standard Rust formatter though. I think that's mostly restricted to the new trees module. Most of the clippy changes in the trees section involve changing `and_then` into `map` and a few redundant closures.

`div_ceil` is an interesting one; there were various cases where it was implemented manually. There are a few changes of manual indexing to iter() in the wavelet matrix code.

 I am curious whether there is any performance impact; I haven't done a benchmark compare yet.

Finally one change that seems silly: the additional brackets are what clippy suggests though they seem entirely redundant here.

```rust
(data[data_index] & ((1 << bit_index) - 1)).count_ones() as usize
```
