### PR TITLE
is_ancestor support.

### DIFF
--- a/src/trees/bp/mod.rs
+++ b/src/trees/bp/mod.rs
@@ -368,6 +368,22 @@ impl<const BLOCK_SIZE: usize> Tree for BpTree<BLOCK_SIZE> {
         self.vec.get(node + 1) == Some(CLOSE_PAREN)
     }
 
+    fn is_ancestor(&self, ancestor: Self::NodeHandle, descendant: Self::NodeHandle) -> bool {
+        debug_assert!(
+            self.vec.get(ancestor) == Some(OPEN_PAREN),
+            "Node handle is invalid"
+        );
+        debug_assert!(
+            self.vec.get(descendant) == Some(OPEN_PAREN),
+            "Node handle is invalid"
+        );
+        ancestor <= descendant
+            && descendant
+                <= self
+                    .close(ancestor)
+                    .expect("Ancestor node handle does not close")
+    }
+
     fn depth(&self, node: Self::NodeHandle) -> u64 {
         debug_assert!(
             self.vec.get(node) == Some(OPEN_PAREN),

--- a/src/trees/bp/tests.rs
+++ b/src/trees/bp/tests.rs
@@ -539,6 +539,38 @@ fn test_is_leaf() {
 }
 
 #[test]
+fn test_is_ancestor() {
+    // (()((())()))
+    // ab cde  f
+    let bits = vec![1, 1, 0, 1, 1, 1, 0, 0, 1, 0, 0, 0];
+    let bv = BitVec::from_bits(&bits);
+    let tree = BpTree::<8>::from_bit_vector(bv);
+    let a = tree.root().unwrap();
+    let b = tree.first_child(a).unwrap();
+    let c = tree.next_sibling(b).unwrap();
+    let d = tree.first_child(c).unwrap();
+    let e = tree.first_child(d).unwrap();
+    let f = tree.next_sibling(d).unwrap();
+
+    assert!(tree.is_ancestor(a, b));
+    assert!(tree.is_ancestor(a, c));
+    assert!(tree.is_ancestor(a, d));
+    assert!(tree.is_ancestor(a, e));
+    assert!(tree.is_ancestor(a, f));
+
+    assert!(!tree.is_ancestor(b, a));
+    assert!(!tree.is_ancestor(b, c));
+    assert!(tree.is_ancestor(c, d));
+    assert!(tree.is_ancestor(c, e));
+    assert!(tree.is_ancestor(c, f));
+    assert!(!tree.is_ancestor(f, e));
+    assert!(!tree.is_ancestor(e, d));
+
+    assert!(tree.is_ancestor(a, a));
+    assert!(tree.is_ancestor(b, b));
+}
+
+#[test]
 fn test_root() {
     let bv = BitVec::from_bits(&[
         1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,

--- a/src/trees/mod.rs
+++ b/src/trees/mod.rs
@@ -47,9 +47,14 @@ pub trait Tree {
     /// If the index is out of bounds, the behavior is unspecified.
     fn node_handle(&self, index: usize) -> Self::NodeHandle;
 
-    /// Returns true, if the node is a leaf.
+    /// Returns true if the node is a leaf.
     /// If `node` is not a valid node handle, the result is meaningless.
     fn is_leaf(&self, node: Self::NodeHandle) -> bool;
+
+    /// Returns true if ancestor is an ancestor of the descendant node
+    ///
+    /// Note that a node is considered an ancestor of itself.
+    fn is_ancestor(&self, ancestor: Self::NodeHandle, descendant: Self::NodeHandle) -> bool;
 
     /// Returns the depth of the node in the tree.
     /// The root node has depth 0.
@@ -97,7 +102,6 @@ pub trait LevelTree: Tree {
 /// Once the full tree has been visited, the caller must call [`build`] to create an instance of the
 /// implementing tree type.
 pub trait DfsTreeBuilder {
-
     /// The tree type constructed with this interface
     type Tree;
 


### PR DESCRIPTION
I've added an `is_ancestor` function described in the XPath paper. 

Note that ancestors are considered to be ancestors of themselves by this measure.  The paper builds TaggedPrec on top of it, which is the last preceding node not an ancestor, and defines this as a different node, so it's not a problem for that.

I'm unsure what to do if close does not complete; right now I let it panic as I don't see how I can determine ancestry without it.
