### PR TITLE
Change usize to u64 for all variables that aren't indices into byte-based structures

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -32,3 +32,13 @@ jobs:
         run: cargo build --verbose --features serde
       - name: Run tests
         run: cargo test --verbose --features serde
+
+  docs:
+    runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: -C target-cpu=x86-64
+      RUSTDOCFLAGS: -C target-cpu=x86-64
+    steps:
+      - uses: actions/checkout@v4
+      - name: Docs
+        run: cargo doc --verbose --all-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vers-vecs"
-version = "1.8.0"
+version = "1.8.1"
 edition = "2021"
 authors = ["Johannes \"Cydhra\" Hengstler"]
 description = "A collection of succinct data structures supported by fast implementations of rank and select queries."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vers-vecs"
-version = "1.7.1"
+version = "1.8.0"
 edition = "2021"
 authors = ["Johannes \"Cydhra\" Hengstler"]
 description = "A collection of succinct data structures supported by fast implementations of rank and select queries."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vers-vecs"
-version = "1.7.0"
+version = "1.7.1"
 edition = "2021"
 authors = ["Johannes \"Cydhra\" Hengstler"]
 description = "A collection of succinct data structures supported by fast implementations of rank and select queries."

--- a/benches/bp.rs
+++ b/benches/bp.rs
@@ -11,7 +11,7 @@ use vers_vecs::trees::{Tree, TreeBuilder};
 
 mod common;
 
-const BLOCK_SIZE: usize = 1024;
+const BLOCK_SIZE: u64 = 1024;
 
 // TODO this function has nlogn runtime, which is a bit too much for the largest trees
 fn generate_tree<R: Rng>(rng: &mut R, nodes: u64) -> BpTree<BLOCK_SIZE> {
@@ -107,7 +107,7 @@ fn bench_navigation(b: &mut Criterion) {
         let mut rng = StdRng::from_seed([0; 32]);
 
         let bp = generate_tree(&mut rng, l as u64);
-        let node_handles = (0..l).map(|i| bp.node_handle(i)).collect::<Vec<_>>();
+        let node_handles = (0..l as u64).map(|i| bp.node_handle(i)).collect::<Vec<_>>();
 
         group.bench_with_input(BenchmarkId::new("parent", l), &l, |b, _| {
             b.iter_batched(

--- a/benches/elias_fano_iterator.rs
+++ b/benches/elias_fano_iterator.rs
@@ -29,7 +29,7 @@ fn bench_ef(b: &mut Criterion) {
 
                 let start = Instant::now();
                 while i < iters {
-                    black_box(ef_vec.get_unchecked(i as usize % l));
+                    black_box(ef_vec.get_unchecked(i % l as u64));
                     i += 1;
                 }
                 time += start.elapsed();

--- a/benches/select_adversarial.rs
+++ b/benches/select_adversarial.rs
@@ -35,7 +35,7 @@ fn select_worst_case(b: &mut Criterion) {
         // construct a vector with only one select block and put its last one bit at the end
         // of the vector
 
-        let mut bit_vec = BitVec::with_capacity(length / 64);
+        let mut bit_vec = BitVec::with_capacity(length as u64 / 64);
         for _ in 0..(1usize << 13) / 64 - 1 {
             bit_vec.append_word(u64::MAX);
         }

--- a/benches/select_iter.rs
+++ b/benches/select_iter.rs
@@ -15,11 +15,11 @@ fn bench_select_iter(b: &mut Criterion) {
         group.bench_with_input(BenchmarkId::new("select queries", l), &l, |b, _| {
             b.iter_custom(|iters| {
                 let mut time = Duration::new(0, 0);
-                let mut i = 0usize;
+                let mut i = 0;
                 let rank1 = bit_vec.rank1(bit_vec.len());
 
                 let start = Instant::now();
-                while (i as u64) < iters {
+                while (i) < iters {
                     black_box(bit_vec.select1(i % rank1));
                     i += 1;
                 }

--- a/benches/sparse_equals.rs
+++ b/benches/sparse_equals.rs
@@ -22,14 +22,14 @@ pub const SIZES: [usize; 7] = [
 const FILL_FACTORS: [f64; 6] = [0.05, 0.1, 0.2, 0.3, 0.4, 0.5];
 
 /// Generate a bitvector with `fill_factors` percent ones at random positions
-fn generate_vector_with_fill(rng: &mut ThreadRng, len: usize, fill_factor: f64) -> BitVec {
+fn generate_vector_with_fill(rng: &mut ThreadRng, len: u64, fill_factor: f64) -> BitVec {
     let mut bit_vec1 = BitVec::from_zeros(len);
 
     // flip exactly fill-factor * len bits so the equality check is not trivial
-    sample(rng, len, (fill_factor * len as f64) as usize)
+    sample(rng, len as usize, (fill_factor * len as f64) as usize)
         .iter()
         .for_each(|i| {
-            bit_vec1.flip_bit(i);
+            bit_vec1.flip_bit(i as u64);
         });
 
     bit_vec1
@@ -39,6 +39,7 @@ fn bench(b: &mut Criterion<TimeDiff>) {
     let mut rng = rand::thread_rng();
 
     for len in SIZES {
+        let len = len as u64;
         let mut group = b.benchmark_group(format!("Equals Benchmark: {}", len));
         group.plot_config(common::plot_config());
 

--- a/readme.md
+++ b/readme.md
@@ -31,8 +31,6 @@ since the intrinsics speed up both `rank` and `select` operations by a factor of
 - `simd`: Enables the use of SIMD instructions for rank and select operations.
 This feature requires AVX-512 support and uses unsafe code.
 It also enables a special iterator for the rank/select bit vector that uses vectorized operations.
-The feature only works on nightly Rust.
-Enabling it on stable Rust is a no-op, because the required CPU features are not available there.
 - `serde`: Enables serialization and deserialization of the data structures using the `serde` crate.
 - `u16_lookup` Enables a larger lookup table for BP tree queries. The larger table requires 128 KiB instead of 4 KiB.
 

--- a/src/bit_vec/fast_rs_vec/bitset.rs
+++ b/src/bit_vec/fast_rs_vec/bitset.rs
@@ -3,11 +3,12 @@
 //! It only exists with the `simd` feature enabled, and since it is slower for sparse vectors,
 //! it is not used as a replacement for the `iter1`/`iter0` methods.
 
+use crate::bit_vec::BitIndex;
 use crate::RsVec;
 use std::mem::size_of;
 
 /// The number of bits in a RsVec that can be processed by AVX instructions at once.
-const VECTOR_SIZE: usize = 16;
+const VECTOR_SIZE: u64 = 16;
 
 // add iterator functions to RsVec
 impl RsVec {
@@ -75,8 +76,8 @@ impl RsVec {
 /// [`SelectIter`]: super::SelectIter
 pub struct BitSetIter<'a, const ZERO: bool> {
     vec: &'a RsVec,
-    base: usize,
-    offsets: [u32; VECTOR_SIZE],
+    base: BitIndex,
+    offsets: [u32; VECTOR_SIZE as usize],
     content_len: u8,
     cursor: u8,
 }
@@ -86,7 +87,7 @@ impl<'a, const ZERO: bool> BitSetIter<'a, ZERO> {
         let mut iter = Self {
             vec,
             base: 0,
-            offsets: [0; VECTOR_SIZE],
+            offsets: [0; VECTOR_SIZE as usize],
             content_len: 0,
             cursor: 0,
         };
@@ -129,7 +130,7 @@ impl<'a, const ZERO: bool> BitSetIter<'a, ZERO> {
 }
 
 impl<const ZERO: bool> Iterator for BitSetIter<'_, ZERO> {
-    type Item = usize;
+    type Item = BitIndex;
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.base >= self.vec.len() {

--- a/src/bit_vec/fast_rs_vec/bitset.rs
+++ b/src/bit_vec/fast_rs_vec/bitset.rs
@@ -3,7 +3,6 @@
 //! It only exists with the `simd` feature enabled, and since it is slower for sparse vectors,
 //! it is not used as a replacement for the `iter1`/`iter0` methods.
 
-use crate::bit_vec::u64;
 use crate::RsVec;
 use std::mem::size_of;
 
@@ -104,7 +103,10 @@ impl<'a, const ZERO: bool> BitSetIter<'a, ZERO> {
 
         unsafe {
             let offsets = _mm512_setr_epi32(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
-            assert!(VECTOR_SIZE <= size_of::<u16>() * 8, "change data types");
+            assert!(
+                VECTOR_SIZE <= size_of::<u16>() as u64 * 8,
+                "change data types"
+            );
             let mut mask = __mmask16::from(data);
             if ZERO {
                 mask = !mask;
@@ -160,6 +162,6 @@ impl<const ZERO: bool> Iterator for BitSetIter<'_, ZERO> {
 
         let offset = self.offsets[self.cursor as usize];
         self.cursor += 1;
-        Some(self.base + offset as usize)
+        Some(self.base + offset as u64)
     }
 }

--- a/src/bit_vec/fast_rs_vec/bitset.rs
+++ b/src/bit_vec/fast_rs_vec/bitset.rs
@@ -73,6 +73,7 @@ impl RsVec {
 /// [`bit_set_iter0`]: RsVec::bit_set_iter0
 /// [`bit_set_iter1`]: RsVec::bit_set_iter1
 /// [`SelectIter`]: super::SelectIter
+#[allow(clippy::cast_possible_truncation)]
 pub struct BitSetIter<'a, const ZERO: bool> {
     vec: &'a RsVec,
     base: u64,
@@ -83,6 +84,7 @@ pub struct BitSetIter<'a, const ZERO: bool> {
 
 impl<'a, const ZERO: bool> BitSetIter<'a, ZERO> {
     pub(super) fn new(vec: &'a RsVec) -> Self {
+        #[allow(clippy::cast_possible_truncation)]
         let mut iter = Self {
             vec,
             base: 0,

--- a/src/bit_vec/fast_rs_vec/bitset.rs
+++ b/src/bit_vec/fast_rs_vec/bitset.rs
@@ -3,7 +3,7 @@
 //! It only exists with the `simd` feature enabled, and since it is slower for sparse vectors,
 //! it is not used as a replacement for the `iter1`/`iter0` methods.
 
-use crate::bit_vec::BitIndex;
+use crate::bit_vec::u64;
 use crate::RsVec;
 use std::mem::size_of;
 
@@ -76,7 +76,7 @@ impl RsVec {
 /// [`SelectIter`]: super::SelectIter
 pub struct BitSetIter<'a, const ZERO: bool> {
     vec: &'a RsVec,
-    base: BitIndex,
+    base: u64,
     offsets: [u32; VECTOR_SIZE as usize],
     content_len: u8,
     cursor: u8,
@@ -130,7 +130,7 @@ impl<'a, const ZERO: bool> BitSetIter<'a, ZERO> {
 }
 
 impl<const ZERO: bool> Iterator for BitSetIter<'_, ZERO> {
-    type Item = BitIndex;
+    type Item = u64;
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.base >= self.vec.len() {

--- a/src/bit_vec/fast_rs_vec/iter.rs
+++ b/src/bit_vec/fast_rs_vec/iter.rs
@@ -425,7 +425,7 @@ macro_rules! gen_iter_impl {
 
         impl<$($life,)? const ZERO: bool> ExactSizeIterator for $name<$($life,)? ZERO> {
             fn len(&self) -> usize {
-                // this may truncate, but we cannot redefine the trait
+                // TODO this may truncate, but we cannot redefine the trait
                 self.next_rank_back.map(|x| x + 1).unwrap_or_default().saturating_sub(self.next_rank) as usize
             }
         }

--- a/src/bit_vec/fast_rs_vec/iter.rs
+++ b/src/bit_vec/fast_rs_vec/iter.rs
@@ -1,5 +1,4 @@
 use crate::bit_vec::fast_rs_vec::{BLOCK_SIZE, SELECT_BLOCK_SIZE, SUPER_BLOCK_SIZE};
-use crate::bit_vec::BitIndex;
 use crate::RsVec;
 use std::iter::FusedIterator;
 use std::num::NonZeroUsize;
@@ -107,7 +106,7 @@ macro_rules! gen_iter_impl {
             }
 
             /// Same implementation like select0, but uses cached indices of last query to speed up search
-            fn select_next_0(&mut self) -> Option<BitIndex> {
+            fn select_next_0(&mut self) -> Option<u64> {
                 let mut rank = self.next_rank;
 
                 if rank >= self.vec.rank0 || self.next_rank_back.is_none() || rank > self.next_rank_back.unwrap() {
@@ -118,7 +117,7 @@ macro_rules! gen_iter_impl {
                 let mut block_index = 0;
 
                 if self.vec.super_blocks.len() > (self.last_super_block + 1)
-                    && self.vec.super_blocks[self.last_super_block + 1].zeros as BitIndex > rank
+                    && self.vec.super_blocks[self.last_super_block + 1].zeros as u64 > rank
                 {
                     // instantly jump to the last searched position
                     super_block = self.last_super_block;
@@ -130,11 +129,11 @@ macro_rules! gen_iter_impl {
                     // OR if the next block has a rank higher than the current rank
                     if self.last_block % (SUPER_BLOCK_SIZE / BLOCK_SIZE) as usize == 15
                         || self.vec.blocks.len() > self.last_block + 1
-                            && self.vec.blocks[self.last_block + 1].zeros as BitIndex > rank
+                            && self.vec.blocks[self.last_block + 1].zeros as u64 > rank
                     {
                         // instantly jump to the last searched position
                         block_index = self.last_block;
-                        rank -= self.vec.blocks[block_index].zeros as BitIndex;
+                        rank -= self.vec.blocks[block_index].zeros as u64;
                     }
                 } else {
                     super_block = self.vec.search_super_block0(super_block, rank);
@@ -148,7 +147,7 @@ macro_rules! gen_iter_impl {
                     self.vec.search_block0(rank, &mut block_index);
 
                     self.last_block = block_index;
-                    rank -= self.vec.blocks[block_index].zeros as BitIndex;
+                    rank -= self.vec.blocks[block_index].zeros as u64;
                 }
 
                 self.next_rank += 1;
@@ -156,7 +155,7 @@ macro_rules! gen_iter_impl {
             }
 
             /// Same implementation like ``select_next_0``, but backwards
-            fn select_next_0_back(&mut self) -> Option<BitIndex> {
+            fn select_next_0_back(&mut self) -> Option<u64> {
                 let mut rank = self.next_rank_back?;
 
                 if self.next_rank_back.is_none() || rank < self.next_rank {
@@ -166,7 +165,7 @@ macro_rules! gen_iter_impl {
                 let mut super_block = self.vec.select_blocks[rank / SELECT_BLOCK_SIZE].index_0;
                 let mut block_index = 0;
 
-                if (self.vec.super_blocks[self.last_super_block_back].zeros as BitIndex) < rank
+                if (self.vec.super_blocks[self.last_super_block_back].zeros as u64) < rank
                 {
                     // instantly jump to the last searched position
                     super_block = self.last_super_block_back;
@@ -175,11 +174,11 @@ macro_rules! gen_iter_impl {
                     // check if current block contains the one and if yes, we don't need to search
                     // this is true IF the zeros before the last block are less than the rank,
                     // since the block before then can't contain it
-                    if self.vec.blocks[self.last_block_back].zeros as BitIndex <= rank
+                    if self.vec.blocks[self.last_block_back].zeros as u64 <= rank
                     {
                         // instantly jump to the last searched position
                         block_index = self.last_block_back;
-                        rank -= self.vec.blocks[block_index].zeros as BitIndex;
+                        rank -= self.vec.blocks[block_index].zeros as u64;
                     }
                 } else {
                     super_block = self.vec.search_super_block0(super_block, rank);
@@ -193,7 +192,7 @@ macro_rules! gen_iter_impl {
                     self.vec.search_block0(rank, &mut block_index);
 
                     self.last_block_back = block_index;
-                    rank -= self.vec.blocks[block_index].zeros as BitIndex;
+                    rank -= self.vec.blocks[block_index].zeros as u64;
                 }
 
                 self.next_rank_back = self.next_rank_back.and_then(|x| if x > 0 { Some(x - 1) } else { None });
@@ -202,7 +201,7 @@ macro_rules! gen_iter_impl {
 
             #[must_use]
             #[allow(clippy::assertions_on_constants)]
-            fn select_next_1(&mut self) -> Option<BitIndex> {
+            fn select_next_1(&mut self) -> Option<u64> {
                 let mut rank = self.next_rank;
 
                 if rank >= self.vec.rank1 || self.next_rank_back.is_none() || rank > self.next_rank_back.unwrap() {
@@ -215,7 +214,7 @@ macro_rules! gen_iter_impl {
                 // check if the last super block still contains the rank, and if yes, we don't need to search
                 if self.vec.super_blocks.len() > (self.last_super_block + 1)
                     && (self.last_super_block + 1) * SUPER_BLOCK_SIZE
-                        - self.vec.super_blocks[self.last_super_block + 1].zeros as BitIndex
+                        - self.vec.super_blocks[self.last_super_block + 1].zeros as u64
                         > rank
                 {
                     // instantly jump to the last searched position
@@ -230,14 +229,14 @@ macro_rules! gen_iter_impl {
                     if self.last_block % (SUPER_BLOCK_SIZE / BLOCK_SIZE) == 15
                         || self.vec.blocks.len() > self.last_block + 1
                             && (self.last_block + 1 - block_at_super_block) * BLOCK_SIZE
-                                - self.vec.blocks[self.last_block + 1].zeros as BitIndex
+                                - self.vec.blocks[self.last_block + 1].zeros as u64
                                 > rank
                     {
                         // instantly jump to the last searched position
                         block_index = self.last_block;
                         let block_at_super_block = super_block * (SUPER_BLOCK_SIZE / BLOCK_SIZE);
                         rank -= (block_index - block_at_super_block) * BLOCK_SIZE
-                            - self.vec.blocks[block_index].zeros as BitIndex;
+                            - self.vec.blocks[block_index].zeros as u64;
                     }
                 } else {
                     super_block = self.vec.search_super_block1(super_block, rank);
@@ -257,7 +256,7 @@ macro_rules! gen_iter_impl {
 
                     self.last_block = block_index;
                     rank -= (block_index - block_at_super_block) * BLOCK_SIZE
-                        - self.vec.blocks[block_index].zeros as BitIndex;
+                        - self.vec.blocks[block_index].zeros as u64;
                 }
 
                 self.next_rank += 1;
@@ -266,7 +265,7 @@ macro_rules! gen_iter_impl {
 
             #[must_use]
             #[allow(clippy::assertions_on_constants)]
-            fn select_next_1_back(&mut self) -> Option<BitIndex> {
+            fn select_next_1_back(&mut self) -> Option<u64> {
                 let mut rank = self.next_rank_back?;
 
                 if self.next_rank_back.is_none() || rank < self.next_rank {
@@ -278,7 +277,7 @@ macro_rules! gen_iter_impl {
 
                 // check if the last super block still contains the rank, and if yes, we don't need to search
                 if (self.last_super_block_back) * SUPER_BLOCK_SIZE
-                        - (self.vec.super_blocks[self.last_super_block_back].zeros as BitIndex)
+                        - (self.vec.super_blocks[self.last_super_block_back].zeros as u64)
                         < rank
                 {
                     // instantly jump to the last searched position
@@ -290,14 +289,14 @@ macro_rules! gen_iter_impl {
                     // this is true IF the ones before the last block are less than the rank,
                     // since the block before then can't contain it
                     if (self.last_block_back - block_at_super_block) * BLOCK_SIZE
-                        - self.vec.blocks[self.last_block_back].zeros as BitIndex
+                        - self.vec.blocks[self.last_block_back].zeros as u64
                             <= rank
                     {
                         // instantly jump to the last searched position
                         block_index = self.last_block_back;
                         let block_at_super_block = super_block * (SUPER_BLOCK_SIZE / BLOCK_SIZE);
                         rank -= (block_index - block_at_super_block) * BLOCK_SIZE
-                            - self.vec.blocks[block_index].zeros as BitIndex;
+                            - self.vec.blocks[block_index].zeros as u64;
                     }
                 } else {
                     super_block = self.vec.search_super_block1(super_block, rank);
@@ -317,7 +316,7 @@ macro_rules! gen_iter_impl {
 
                     self.last_block_back = block_index;
                     rank -= (block_index - block_at_super_block) * BLOCK_SIZE
-                        - self.vec.blocks[block_index].zeros as BitIndex;
+                        - self.vec.blocks[block_index].zeros as u64;
                 }
 
                 self.next_rank_back = self.next_rank_back.and_then(|x| if x > 0 { Some(x - 1) } else { None });
@@ -360,7 +359,7 @@ macro_rules! gen_iter_impl {
         }
 
         impl<$($life,)? const ZERO: bool> Iterator for $name<$($life,)? ZERO> {
-            type Item = BitIndex;
+            type Item = u64;
 
             fn next(&mut self) -> Option<Self::Item> {
                 if ZERO {
@@ -463,11 +462,11 @@ macro_rules! gen_iter_impl {
 #[must_use]
 pub struct SelectIter<'a, const ZERO: bool> {
     pub(crate) vec: &'a RsVec,
-    next_rank: BitIndex,
+    next_rank: u64,
 
     // rank back is none, iff it points to element -1 (i.e. element 0 has been consumed by
     // a call to next_back()). It can be Some(..) even if the iterator is empty
-    next_rank_back: Option<BitIndex>,
+    next_rank_back: Option<u64>,
 
     /// the last index in the super block structure where we found a bit
     last_super_block: usize,
@@ -516,11 +515,11 @@ gen_iter_impl!('a, SelectIter);
 // this owning iterator became necessary
 pub struct SelectIntoIter<const ZERO: bool> {
     pub(crate) vec: RsVec,
-    next_rank: BitIndex,
+    next_rank: u64,
 
     // rank back is none, iff it points to element -1 (i.e. element 0 has been consumed by
     // a call to next_back()). It can be Some(..) even if the iterator is empty
-    next_rank_back: Option<BitIndex>,
+    next_rank_back: Option<u64>,
 
     /// the last index in the super block structure where we found a bit
     last_super_block: usize,

--- a/src/bit_vec/fast_rs_vec/iter.rs
+++ b/src/bit_vec/fast_rs_vec/iter.rs
@@ -329,7 +329,7 @@ macro_rules! gen_iter_impl {
             /// [this issue](https://github.com/rust-lang/rust/issues/77404).
             /// As soon as it is stabilized, this method will be removed and replaced with a custom
             /// implementation in the iterator impl.
-            pub(super) fn advance_by(&mut self, n: usize) -> Result<(), NonZeroUsize> {
+            pub fn advance_by(&mut self, n: usize) -> Result<(), NonZeroUsize> {
                 if self.len() >= n {
                     self.next_rank += n as u64;
                     Ok(())
@@ -346,7 +346,7 @@ macro_rules! gen_iter_impl {
             /// [this issue](https://github.com/rust-lang/rust/issues/77404).
             /// As soon as it is stabilized, this method will be removed and replaced with a custom
             /// implementation in the double ended iterator impl.
-            pub(super) fn advance_back_by(&mut self, n: usize) -> Result<(), NonZeroUsize> {
+            pub fn advance_back_by(&mut self, n: usize) -> Result<(), NonZeroUsize> {
                 // TODO self.len() cannot work if sizeof(usize) < sizeof(u64)
                 if self.len() >= n {
                     self.next_rank_back = self.next_rank_back.map(|x| x - n as u64);

--- a/src/bit_vec/fast_rs_vec/iter.rs
+++ b/src/bit_vec/fast_rs_vec/iter.rs
@@ -405,6 +405,12 @@ macro_rules! gen_iter_impl {
                 (self.len(), Some(self.len()))
             }
 
+            /// Returns the exact number of elements that this iterator would iterate over. Does not
+            /// call `next` internally.
+            ///
+            /// # Panics
+            /// If the vector contains more than `usize::MAX` elements, calling `count()` on the iterator will
+            /// cause it to panic.
             fn count(self) -> usize
             where
                 Self: Sized,

--- a/src/bit_vec/fast_rs_vec/iter.rs
+++ b/src/bit_vec/fast_rs_vec/iter.rs
@@ -162,7 +162,7 @@ macro_rules! gen_iter_impl {
                     return None;
                 }
 
-                let mut super_block = self.vec.select_blocks[rank / SELECT_BLOCK_SIZE].index_0;
+                let mut super_block = self.vec.select_blocks[(rank / SELECT_BLOCK_SIZE) as usize].index_0;
                 let mut block_index = 0;
 
                 if (self.vec.super_blocks[self.last_super_block_back].zeros as u64) < rank
@@ -188,7 +188,7 @@ macro_rules! gen_iter_impl {
 
                 // if the block index is not zero, we already found the block, and need only update the word
                 if block_index == 0 {
-                    block_index = super_block * (SUPER_BLOCK_SIZE / BLOCK_SIZE);
+                    block_index = super_block * (SUPER_BLOCK_SIZE / BLOCK_SIZE) as usize;
                     self.vec.search_block0(rank, &mut block_index);
 
                     self.last_block_back = block_index;
@@ -208,54 +208,54 @@ macro_rules! gen_iter_impl {
                     return None;
                 }
 
-                let mut super_block = self.vec.select_blocks[rank / SELECT_BLOCK_SIZE].index_1;
+                let mut super_block = self.vec.select_blocks[(rank / SELECT_BLOCK_SIZE) as usize].index_1;
                 let mut block_index = 0;
 
                 // check if the last super block still contains the rank, and if yes, we don't need to search
                 if self.vec.super_blocks.len() > (self.last_super_block + 1)
-                    && (self.last_super_block + 1) * SUPER_BLOCK_SIZE
+                    && (self.last_super_block + 1) as u64 * SUPER_BLOCK_SIZE
                         - self.vec.super_blocks[self.last_super_block + 1].zeros as u64
                         > rank
                 {
                     // instantly jump to the last searched position
                     super_block = self.last_super_block;
-                    let block_at_super_block = super_block * (SUPER_BLOCK_SIZE / BLOCK_SIZE);
-                    rank -= super_block * SUPER_BLOCK_SIZE - self.vec.super_blocks[super_block].zeros;
+                    let block_at_super_block = super_block * (SUPER_BLOCK_SIZE / BLOCK_SIZE) as usize;
+                    rank -= super_block as u64 * SUPER_BLOCK_SIZE - self.vec.super_blocks[super_block].zeros;
 
                     // check if current block contains the one and if yes, we don't need to search
                     // this is true IF the last_block is either the last block in a super block,
                     // in which case it must be this block, because we know the rank is within the super block,
                     // OR if the next block has a rank higher than the current rank
-                    if self.last_block % (SUPER_BLOCK_SIZE / BLOCK_SIZE) == 15
+                    if self.last_block as u64 % (SUPER_BLOCK_SIZE / BLOCK_SIZE) == 15
                         || self.vec.blocks.len() > self.last_block + 1
-                            && (self.last_block + 1 - block_at_super_block) * BLOCK_SIZE
+                            && (self.last_block + 1 - block_at_super_block) as u64 * BLOCK_SIZE
                                 - self.vec.blocks[self.last_block + 1].zeros as u64
                                 > rank
                     {
                         // instantly jump to the last searched position
                         block_index = self.last_block;
-                        let block_at_super_block = super_block * (SUPER_BLOCK_SIZE / BLOCK_SIZE);
-                        rank -= (block_index - block_at_super_block) * BLOCK_SIZE
+                        let block_at_super_block = super_block * (SUPER_BLOCK_SIZE / BLOCK_SIZE) as usize;
+                        rank -= (block_index - block_at_super_block) as u64 * BLOCK_SIZE
                             - self.vec.blocks[block_index].zeros as u64;
                     }
                 } else {
                     super_block = self.vec.search_super_block1(super_block, rank);
 
                     self.last_super_block = super_block;
-                    rank -= super_block * SUPER_BLOCK_SIZE - self.vec.super_blocks[super_block].zeros;
+                    rank -= super_block as u64 * SUPER_BLOCK_SIZE - self.vec.super_blocks[super_block].zeros;
                 }
 
                 // if the block index is not zero, we already found the block, and need only update the word
                 if block_index == 0 {
                     // full binary search for block that contains the rank, manually loop-unrolled, because
                     // LLVM doesn't do it for us, but it gains just under 20% performance
-                    let block_at_super_block = super_block * (SUPER_BLOCK_SIZE / BLOCK_SIZE);
+                    let block_at_super_block = super_block * (SUPER_BLOCK_SIZE / BLOCK_SIZE) as usize;
                     block_index = block_at_super_block;
                     self.vec
                         .search_block1(rank, block_at_super_block, &mut block_index);
 
                     self.last_block = block_index;
-                    rank -= (block_index - block_at_super_block) * BLOCK_SIZE
+                    rank -= (block_index - block_at_super_block) as u64 * BLOCK_SIZE
                         - self.vec.blocks[block_index].zeros as u64;
                 }
 
@@ -272,50 +272,50 @@ macro_rules! gen_iter_impl {
                     return None;
                 }
 
-                let mut super_block = self.vec.select_blocks[rank / SELECT_BLOCK_SIZE].index_1;
+                let mut super_block = self.vec.select_blocks[(rank / SELECT_BLOCK_SIZE) as usize].index_1;
                 let mut block_index = 0;
 
                 // check if the last super block still contains the rank, and if yes, we don't need to search
-                if (self.last_super_block_back) * SUPER_BLOCK_SIZE
+                if self.last_super_block_back as u64 * SUPER_BLOCK_SIZE
                         - (self.vec.super_blocks[self.last_super_block_back].zeros as u64)
                         < rank
                 {
                     // instantly jump to the last searched position
                     super_block = self.last_super_block_back;
-                    let block_at_super_block = super_block * (SUPER_BLOCK_SIZE / BLOCK_SIZE);
-                    rank -= super_block * SUPER_BLOCK_SIZE - self.vec.super_blocks[super_block].zeros;
+                    let block_at_super_block = super_block * (SUPER_BLOCK_SIZE / BLOCK_SIZE) as usize;
+                    rank -= super_block as u64 * SUPER_BLOCK_SIZE - self.vec.super_blocks[super_block].zeros;
 
                     // check if current block contains the one and if yes, we don't need to search
                     // this is true IF the ones before the last block are less than the rank,
                     // since the block before then can't contain it
-                    if (self.last_block_back - block_at_super_block) * BLOCK_SIZE
+                    if (self.last_block_back - block_at_super_block) as u64 * BLOCK_SIZE
                         - self.vec.blocks[self.last_block_back].zeros as u64
                             <= rank
                     {
                         // instantly jump to the last searched position
                         block_index = self.last_block_back;
-                        let block_at_super_block = super_block * (SUPER_BLOCK_SIZE / BLOCK_SIZE);
-                        rank -= (block_index - block_at_super_block) * BLOCK_SIZE
+                        let block_at_super_block = super_block * (SUPER_BLOCK_SIZE / BLOCK_SIZE) as usize;
+                        rank -= (block_index - block_at_super_block) as u64 * BLOCK_SIZE
                             - self.vec.blocks[block_index].zeros as u64;
                     }
                 } else {
                     super_block = self.vec.search_super_block1(super_block, rank);
 
                     self.last_super_block_back = super_block;
-                    rank -= super_block * SUPER_BLOCK_SIZE - self.vec.super_blocks[super_block].zeros;
+                    rank -= super_block as u64 * SUPER_BLOCK_SIZE - self.vec.super_blocks[super_block].zeros;
                 }
 
                 // if the block index is not zero, we already found the block, and need only update the word
                 if block_index == 0 {
                     // full binary search for block that contains the rank, manually loop-unrolled, because
                     // LLVM doesn't do it for us, but it gains just under 20% performance
-                    let block_at_super_block = super_block * (SUPER_BLOCK_SIZE / BLOCK_SIZE);
+                    let block_at_super_block = super_block * (SUPER_BLOCK_SIZE / BLOCK_SIZE) as usize;
                     block_index = block_at_super_block;
                     self.vec
                         .search_block1(rank, block_at_super_block, &mut block_index);
 
                     self.last_block_back = block_index;
-                    rank -= (block_index - block_at_super_block) * BLOCK_SIZE
+                    rank -= (block_index - block_at_super_block) as u64 * BLOCK_SIZE
                         - self.vec.blocks[block_index].zeros as u64;
                 }
 
@@ -331,11 +331,11 @@ macro_rules! gen_iter_impl {
             /// implementation in the iterator impl.
             pub(super) fn advance_by(&mut self, n: usize) -> Result<(), NonZeroUsize> {
                 if self.len() >= n {
-                    self.next_rank += n;
+                    self.next_rank += n as u64;
                     Ok(())
                 } else {
                     let len = self.len();
-                    self.next_rank += len;
+                    self.next_rank += len as u64;
                     Err(NonZeroUsize::new(n - len).unwrap())
                 }
             }
@@ -347,12 +347,13 @@ macro_rules! gen_iter_impl {
             /// As soon as it is stabilized, this method will be removed and replaced with a custom
             /// implementation in the double ended iterator impl.
             pub(super) fn advance_back_by(&mut self, n: usize) -> Result<(), NonZeroUsize> {
+                // TODO self.len() cannot work if sizeof(usize) < sizeof(u64)
                 if self.len() >= n {
-                    self.next_rank_back = self.next_rank_back.map(|x| x - n);
+                    self.next_rank_back = self.next_rank_back.map(|x| x - n as u64);
                     Ok(())
                 } else {
                     let len = self.len();
-                    self.next_rank_back = self.next_rank_back.map(|x| x - len);
+                    self.next_rank_back = self.next_rank_back.map(|x| x - len as u64);
                     Err(NonZeroUsize::new(n - len).unwrap())
                 }
             }

--- a/src/bit_vec/fast_rs_vec/iter.rs
+++ b/src/bit_vec/fast_rs_vec/iter.rs
@@ -464,7 +464,6 @@ macro_rules! gen_iter_impl {
                     panic!("calling len() on an iterator containing more than usize::MAX elements is forbidden");
                 }
 
-                // TODO this may truncate, but we cannot redefine the trait
                 self.next_rank_back.map(|x| x + 1).unwrap_or_default().saturating_sub(self.next_rank) as usize
             }
         }

--- a/src/bit_vec/fast_rs_vec/iter.rs
+++ b/src/bit_vec/fast_rs_vec/iter.rs
@@ -323,12 +323,16 @@ macro_rules! gen_iter_impl {
                 Some(self.vec.search_word_in_block1(rank, block_index))
             }
 
-            /// Advances the iterator by `n` elements. Returns an error if the iterator does not have
-            /// enough elements left. Does not call `next` internally.
+            /// Advances the iterator by `n` elements.
+            /// Does not call `next` internally.
             /// This method is currently being added to the iterator trait, see
             /// [this issue](https://github.com/rust-lang/rust/issues/77404).
             /// As soon as it is stabilized, this method will be removed and replaced with a custom
             /// implementation in the iterator impl.
+            ///
+            /// # Errors
+            /// If the iterator does not hold `n` elements,
+            /// all remaining elements are skipped, and an error with the overflow is returned.
             pub fn advance_by(&mut self, n: usize) -> Result<(), NonZeroUsize> {
                 if self.len() >= n {
                     self.next_rank += n as u64;
@@ -340,14 +344,17 @@ macro_rules! gen_iter_impl {
                 }
             }
 
-            /// Advances the iterator back by `n` elements. Returns an error if the iterator does not have
-            /// enough elements left. Does not call `next_back` internally.
+            /// Advances the iterator back by `n` elements.
+            /// Does not call `next_back` internally.
             /// This method is currently being added to the iterator trait, see
             /// [this issue](https://github.com/rust-lang/rust/issues/77404).
             /// As soon as it is stabilized, this method will be removed and replaced with a custom
             /// implementation in the double ended iterator impl.
+            ///
+            /// # Errors
+            /// If the iterator does not hold `n` elements,
+            /// all remaining elements are skipped, and an error with the overflow is returned.
             pub fn advance_back_by(&mut self, n: usize) -> Result<(), NonZeroUsize> {
-                // TODO self.len() cannot work if sizeof(usize) < sizeof(u64)
                 if self.len() >= n {
                     self.next_rank_back = self.next_rank_back.map(|x| x - n as u64);
                     Ok(())

--- a/src/bit_vec/fast_rs_vec/mod.rs
+++ b/src/bit_vec/fast_rs_vec/mod.rs
@@ -441,16 +441,16 @@ impl RsVec {
 
         let iter: SelectIter<ZERO> = self.select_iter();
 
+        let len = if ZERO { self.rank0 } else { self.rank1 };
+
         // we need to manually enumerate() the iter, because the number of set bits could exceed
         // the size of usize.
-        let mut rank = 0;
-        for bit_index in iter {
+        for (rank, bit_index) in (0..len).zip(iter) {
             // since rank is inlined, we get dead code elimination depending on ZERO
             if (other.get_unchecked(bit_index) == 0) != ZERO || other.rank(ZERO, bit_index) != rank
             {
                 return false;
             }
-            rank += 1;
         }
 
         true

--- a/src/bit_vec/fast_rs_vec/mod.rs
+++ b/src/bit_vec/fast_rs_vec/mod.rs
@@ -124,8 +124,8 @@ impl RsVec {
         for (word_idx, &word) in vec.data.iter().enumerate() {
             // if we moved past a block boundary, append the block information for the previous
             // block and reset the counter if we moved past a super-block boundary.
-            if word_idx as u64 % (BLOCK_SIZE / WORD_SIZE) == 0 {
-                if word_idx as u64 % (SUPER_BLOCK_SIZE / WORD_SIZE) == 0 {
+            if (word_idx as u64).is_multiple_of(BLOCK_SIZE / WORD_SIZE) {
+                if (word_idx as u64).is_multiple_of(SUPER_BLOCK_SIZE / WORD_SIZE) {
                     total_zeros += current_zeros;
                     current_zeros = 0;
                     super_blocks.push(SuperBlockDescriptor { zeros: total_zeros });

--- a/src/bit_vec/fast_rs_vec/mod.rs
+++ b/src/bit_vec/fast_rs_vec/mod.rs
@@ -443,14 +443,14 @@ impl RsVec {
 
         // we need to manually enumerate() the iter, because the number of set bits could exceed
         // the size of usize.
-        let mut bit_index = 0;
-        for rank in iter {
+        let mut rank = 0;
+        for bit_index in iter {
             // since rank is inlined, we get dead code elimination depending on ZERO
             if (other.get_unchecked(bit_index) == 0) != ZERO || other.rank(ZERO, bit_index) != rank
             {
                 return false;
             }
-            bit_index += 1;
+            rank += 1;
         }
 
         true

--- a/src/bit_vec/fast_rs_vec/mod.rs
+++ b/src/bit_vec/fast_rs_vec/mod.rs
@@ -144,7 +144,7 @@ impl RsVec {
             let mut new_zeros = word.count_zeros() as usize;
 
             // in the last block, remove remaining zeros of limb that aren't part of the vector
-            if idx == vec.data.len() - 1 && vec.len % WORD_SIZE > 0 {
+            if idx == vec.data.len() - 1 && !vec.len.is_multiple_of(WORD_SIZE) {
                 let mask = (1 << (vec.len % WORD_SIZE)) - 1;
                 new_zeros -= (word | mask).count_zeros() as usize;
             }
@@ -477,9 +477,9 @@ impl RsVec {
         }
 
         // if last incomplete block exists, test it without junk data
-        if self.len % 64 > 0
-            && self.data[self.len / 64] & ((1 << (self.len % 64)) - 1)
-                != other.data[self.len / 64] & ((1 << (other.len % 64)) - 1)
+        if !self.len.is_multiple_of(WORD_SIZE)
+            && self.data[self.len / WORD_SIZE] & ((1 << (self.len % WORD_SIZE)) - 1)
+                != other.data[self.len / WORD_SIZE] & ((1 << (other.len % WORD_SIZE)) - 1)
         {
             return false;
         }

--- a/src/bit_vec/fast_rs_vec/mod.rs
+++ b/src/bit_vec/fast_rs_vec/mod.rs
@@ -17,10 +17,10 @@ pub use iter::*;
 use crate::util::impl_vector_iterator;
 use crate::BitVec;
 
-use super::WORD_SIZE;
+use super::{BitIndex, WORD_SIZE};
 
 /// Size of a block in the bitvector.
-const BLOCK_SIZE: usize = 512;
+const BLOCK_SIZE: BitIndex = 512;
 
 /// Size of a super block in the bitvector. Super-blocks exist to decrease the memory overhead
 /// of block descriptors.
@@ -30,12 +30,12 @@ const BLOCK_SIZE: usize = 512;
 /// impact on the performance of select queries. The larger the super block size, the deeper will
 /// a binary search be. We found 2^13 to be a good compromise between memory overhead and
 /// performance.
-const SUPER_BLOCK_SIZE: usize = 1 << 13;
+const SUPER_BLOCK_SIZE: BitIndex = 1 << 13;
 
 /// Size of a select block. The select block is used to speed up select queries. The select block
 /// contains the indices of every `SELECT_BLOCK_SIZE`'th 1-bit and 0-bit in the bitvector.
 /// The smaller this block-size, the faster are select queries, but the more memory is used.
-const SELECT_BLOCK_SIZE: usize = 1 << 13;
+const SELECT_BLOCK_SIZE: BitIndex = 1 << 13;
 
 /// Meta-data for a block. The `zeros` field stores the number of zeros up to the block,
 /// beginning from the last super-block boundary. This means the first block in a super-block
@@ -53,7 +53,7 @@ struct BlockDescriptor {
 #[derive(Clone, Copy, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 struct SuperBlockDescriptor {
-    zeros: usize,
+    zeros: BitIndex,
 }
 
 /// Meta-data for the select query. Each entry i in the select vector contains the indices to find
@@ -86,12 +86,12 @@ struct SelectSuperBlockDescriptor {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct RsVec {
     data: Vec<u64>,
-    len: usize,
+    len: BitIndex,
     blocks: Vec<BlockDescriptor>,
     super_blocks: Vec<SuperBlockDescriptor>,
     select_blocks: Vec<SelectSuperBlockDescriptor>,
-    pub(crate) rank0: usize,
-    pub(crate) rank1: usize,
+    pub(crate) rank0: BitIndex,
+    pub(crate) rank1: BitIndex,
 }
 
 impl RsVec {
@@ -106,8 +106,8 @@ impl RsVec {
     pub fn from_bit_vec(vec: BitVec) -> RsVec {
         // Construct the block descriptor meta data. Each block descriptor contains the number of
         // zeros in the super-block, up to but excluding the block.
-        let mut blocks = Vec::with_capacity(vec.len() / BLOCK_SIZE + 1);
-        let mut super_blocks = Vec::with_capacity(vec.len() / SUPER_BLOCK_SIZE + 1);
+        let mut blocks = Vec::with_capacity(vec.len() / BLOCK_SIZE as usize + 1);
+        let mut super_blocks = Vec::with_capacity(vec.len() / SUPER_BLOCK_SIZE as usize + 1);
         let mut select_blocks = Vec::new();
 
         // sentinel value
@@ -116,16 +116,16 @@ impl RsVec {
             index_1: 0,
         });
 
-        let mut total_zeros: usize = 0;
-        let mut current_zeros: usize = 0;
+        let mut total_zeros: BitIndex = 0;
+        let mut current_zeros: BitIndex = 0;
         let mut last_zero_select_block: usize = 0;
         let mut last_one_select_block: usize = 0;
 
-        for (idx, &word) in vec.data.iter().enumerate() {
+        for (word_idx, &word) in vec.data.iter().enumerate() {
             // if we moved past a block boundary, append the block information for the previous
             // block and reset the counter if we moved past a super-block boundary.
-            if idx % (BLOCK_SIZE / WORD_SIZE) == 0 {
-                if idx % (SUPER_BLOCK_SIZE / WORD_SIZE) == 0 {
+            if word_idx as BitIndex % (BLOCK_SIZE / WORD_SIZE) == 0 {
+                if word_idx as BitIndex % (SUPER_BLOCK_SIZE / WORD_SIZE) == 0 {
                     total_zeros += current_zeros;
                     current_zeros = 0;
                     super_blocks.push(SuperBlockDescriptor { zeros: total_zeros });
@@ -141,40 +141,43 @@ impl RsVec {
             // count the zeros in the current word and add them to the counter
             // the last word may contain padding zeros, which should not be counted,
             // but since we do not append the last block descriptor, this is not a problem
-            let mut new_zeros = word.count_zeros() as usize;
+            let mut new_zeros = word.count_zeros() as BitIndex;
 
             // in the last block, remove remaining zeros of limb that aren't part of the vector
-            if idx == vec.data.len() - 1 && vec.len % WORD_SIZE > 0 {
+            if word_idx == vec.data.len() - 1 && vec.len % WORD_SIZE > 0 {
                 let mask = (1 << (vec.len % WORD_SIZE)) - 1;
-                new_zeros -= (word | mask).count_zeros() as usize;
+                new_zeros -= (word | mask).count_zeros() as BitIndex;
             }
 
             let all_zeros = total_zeros + current_zeros + new_zeros;
             if all_zeros / SELECT_BLOCK_SIZE > (total_zeros + current_zeros) / SELECT_BLOCK_SIZE {
-                if all_zeros / SELECT_BLOCK_SIZE == select_blocks.len() {
+                if (all_zeros / SELECT_BLOCK_SIZE) as usize == select_blocks.len() {
                     select_blocks.push(SelectSuperBlockDescriptor {
                         index_0: super_blocks.len() - 1,
                         index_1: 0,
                     });
                 } else {
-                    select_blocks[all_zeros / SELECT_BLOCK_SIZE].index_0 = super_blocks.len() - 1;
+                    select_blocks[(all_zeros / SELECT_BLOCK_SIZE) as usize].index_0 =
+                        super_blocks.len() - 1;
                 }
 
                 last_zero_select_block += 1;
             }
 
-            let total_bits = (idx + 1) * WORD_SIZE;
+            let total_bits = (word_idx as BitIndex + 1) * WORD_SIZE;
             let all_ones = total_bits - all_zeros;
             if all_ones / SELECT_BLOCK_SIZE
-                > (idx * WORD_SIZE - total_zeros - current_zeros) / SELECT_BLOCK_SIZE
+                > (word_idx as BitIndex * WORD_SIZE - total_zeros - current_zeros)
+                    / SELECT_BLOCK_SIZE
             {
-                if all_ones / SELECT_BLOCK_SIZE == select_blocks.len() {
+                if (all_ones / SELECT_BLOCK_SIZE) as usize == select_blocks.len() {
                     select_blocks.push(SelectSuperBlockDescriptor {
                         index_0: 0,
                         index_1: super_blocks.len() - 1,
                     });
                 } else {
-                    select_blocks[all_ones / SELECT_BLOCK_SIZE].index_1 = super_blocks.len() - 1;
+                    select_blocks[(all_ones / SELECT_BLOCK_SIZE) as usize].index_1 =
+                        super_blocks.len() - 1;
                 }
 
                 last_one_select_block += 1;
@@ -230,7 +233,7 @@ impl RsVec {
     /// # Parameters
     /// - `pos`: The position of the bit to return the rank of.
     #[must_use]
-    pub fn rank0(&self, pos: usize) -> usize {
+    pub fn rank0(&self, pos: BitIndex) -> BitIndex {
         self.rank(true, pos)
     }
 
@@ -242,7 +245,7 @@ impl RsVec {
     /// # Parameters
     /// - `pos`: The position of the bit to return the rank of.
     #[must_use]
-    pub fn rank1(&self, pos: usize) -> usize {
+    pub fn rank1(&self, pos: BitIndex) -> BitIndex {
         self.rank(false, pos)
     }
 
@@ -250,7 +253,7 @@ impl RsVec {
     // branch elimination profits alone should make it worth it.
     #[allow(clippy::inline_always)]
     #[inline(always)]
-    fn rank(&self, zero: bool, pos: usize) -> usize {
+    fn rank(&self, zero: bool, pos: BitIndex) -> BitIndex {
         #[allow(clippy::collapsible_else_if)]
         // readability and more obvious where dead branch elimination happens
         if zero {
@@ -263,39 +266,40 @@ impl RsVec {
             }
         }
 
-        let index = pos / WORD_SIZE;
-        let block_index = pos / BLOCK_SIZE;
-        let super_block_index = pos / SUPER_BLOCK_SIZE;
+        let index = (pos / WORD_SIZE) as usize;
+        let block_index = (pos / BLOCK_SIZE) as usize;
+        let super_block_index = (pos / SUPER_BLOCK_SIZE) as usize;
         let mut rank = 0;
 
         // at first add the number of zeros/ones before the current super block
         rank += if zero {
             self.super_blocks[super_block_index].zeros
         } else {
-            (super_block_index * SUPER_BLOCK_SIZE) - self.super_blocks[super_block_index].zeros
+            (super_block_index as BitIndex * SUPER_BLOCK_SIZE)
+                - self.super_blocks[super_block_index].zeros
         };
 
         // then add the number of zeros/ones before the current block
         rank += if zero {
-            self.blocks[block_index].zeros as usize
+            self.blocks[block_index].zeros as BitIndex
         } else {
-            ((block_index % (SUPER_BLOCK_SIZE / BLOCK_SIZE)) * BLOCK_SIZE)
-                - self.blocks[block_index].zeros as usize
+            ((block_index as BitIndex % (SUPER_BLOCK_SIZE / BLOCK_SIZE)) * BLOCK_SIZE)
+                - self.blocks[block_index].zeros as BitIndex
         };
 
         // naive popcount of blocks
-        for &i in &self.data[(block_index * BLOCK_SIZE) / WORD_SIZE..index] {
+        for &i in &self.data[((block_index as BitIndex * BLOCK_SIZE) / WORD_SIZE) as usize..index] {
             rank += if zero {
-                i.count_zeros() as usize
+                i.count_zeros() as BitIndex
             } else {
-                i.count_ones() as usize
+                i.count_ones() as BitIndex
             };
         }
 
         rank += if zero {
-            (!self.data[index] & ((1 << (pos % WORD_SIZE)) - 1)).count_ones() as usize
+            (!self.data[index] & ((1 << (pos % WORD_SIZE)) - 1)).count_ones() as BitIndex
         } else {
-            (self.data[index] & ((1 << (pos % WORD_SIZE)) - 1)).count_ones() as usize
+            (self.data[index] & ((1 << (pos % WORD_SIZE)) - 1)).count_ones() as BitIndex
         };
 
         rank
@@ -303,7 +307,7 @@ impl RsVec {
 
     /// Return the length of the vector, i.e. the number of bits it contains.
     #[must_use]
-    pub fn len(&self) -> usize {
+    pub fn len(&self) -> BitIndex {
         self.len
     }
 
@@ -317,7 +321,7 @@ impl RsVec {
     /// bit of the returned u64 word.
     /// If the position is larger than the length of the vector, `None` is returned.
     #[must_use]
-    pub fn get(&self, pos: usize) -> Option<u64> {
+    pub fn get(&self, pos: BitIndex) -> Option<u64> {
         if pos >= self.len() {
             None
         } else {
@@ -331,8 +335,8 @@ impl RsVec {
     /// # Panics
     /// This function may panic if `pos >= self.len()` (alternatively, it may return garbage).
     #[must_use]
-    pub fn get_unchecked(&self, pos: usize) -> u64 {
-        (self.data[pos / WORD_SIZE] >> (pos % WORD_SIZE)) & 1
+    pub fn get_unchecked(&self, pos: BitIndex) -> u64 {
+        (self.data[(pos / WORD_SIZE) as usize] >> (pos % WORD_SIZE)) & 1
     }
 
     /// Return multiple bits at the given position. The number of bits to return is given by `len`.
@@ -341,7 +345,7 @@ impl RsVec {
     /// None is returned (even if the query partially overlaps with the vector).
     /// If the length of the query is larger than 64, None is returned.
     #[must_use]
-    pub fn get_bits(&self, pos: usize, len: usize) -> Option<u64> {
+    pub fn get_bits(&self, pos: BitIndex, len: u64) -> Option<u64> {
         if len > WORD_SIZE {
             return None;
         }
@@ -370,13 +374,14 @@ impl RsVec {
     #[must_use]
     #[allow(clippy::comparison_chain)] // readability
     #[allow(clippy::cast_possible_truncation)] // parameter must be out of scope for this to happen
-    pub fn get_bits_unchecked(&self, pos: usize, len: usize) -> u64 {
+    pub fn get_bits_unchecked(&self, pos: BitIndex, len: u64) -> u64 {
         debug_assert!(len <= WORD_SIZE);
-        let partial_word = self.data[pos / WORD_SIZE] >> (pos % WORD_SIZE);
+        let partial_word = self.data[(pos / WORD_SIZE) as usize] >> (pos % WORD_SIZE);
         if pos % WORD_SIZE + len <= WORD_SIZE {
             partial_word & 1u64.checked_shl(len as u32).unwrap_or(0).wrapping_sub(1)
         } else {
-            (partial_word | (self.data[pos / WORD_SIZE + 1] << (WORD_SIZE - pos % WORD_SIZE)))
+            (partial_word
+                | (self.data[(pos / WORD_SIZE + 1) as usize] << (WORD_SIZE - pos % WORD_SIZE)))
                 & 1u64.checked_shl(len as u32).unwrap_or(0).wrapping_sub(1)
         }
     }
@@ -437,12 +442,16 @@ impl RsVec {
 
         let iter: SelectIter<ZERO> = self.select_iter();
 
-        for (rank, bit_index) in iter.enumerate() {
+        // we need to manually enumerate() the iter, because the number of set bits could exceed
+        // the size of usize.
+        let mut bit_index = 0;
+        for rank in iter {
             // since rank is inlined, we get dead code elimination depending on ZERO
             if (other.get_unchecked(bit_index) == 0) != ZERO || other.rank(ZERO, bit_index) != rank
             {
                 return false;
             }
+            bit_index += 1;
         }
 
         true
@@ -468,9 +477,9 @@ impl RsVec {
             return false;
         }
 
-        if self.data[..self.len / 64]
+        if self.data[..(self.len / WORD_SIZE) as usize]
             .iter()
-            .zip(other.data[..other.len / 64].iter())
+            .zip(other.data[..(other.len / 64) as usize].iter())
             .any(|(a, b)| a != b)
         {
             return false;
@@ -478,8 +487,9 @@ impl RsVec {
 
         // if last incomplete block exists, test it without junk data
         if self.len % 64 > 0
-            && self.data[self.len / 64] & ((1 << (self.len % 64)) - 1)
-                != other.data[self.len / 64] & ((1 << (other.len % 64)) - 1)
+            && self.data[(self.len / WORD_SIZE) as usize] & ((1 << (self.len % WORD_SIZE)) - 1)
+                != other.data[(self.len / WORD_SIZE) as usize]
+                    & ((1 << (other.len % WORD_SIZE)) - 1)
         {
             return false;
         }

--- a/src/bit_vec/fast_rs_vec/select.rs
+++ b/src/bit_vec/fast_rs_vec/select.rs
@@ -1,7 +1,7 @@
 // Select code is in here to keep it more organized.
 
 use crate::bit_vec::fast_rs_vec::{BLOCK_SIZE, SELECT_BLOCK_SIZE, SUPER_BLOCK_SIZE};
-use crate::bit_vec::WORD_SIZE;
+use crate::bit_vec::{BitIndex, WORD_SIZE};
 use crate::util::pdep::Pdep;
 use crate::util::unroll;
 
@@ -17,12 +17,12 @@ impl super::RsVec {
     /// If the rank is larger than the number of 0-bits in the vector, the vector length is returned.
     #[must_use]
     #[allow(clippy::assertions_on_constants)]
-    pub fn select0(&self, mut rank: usize) -> usize {
+    pub fn select0(&self, mut rank: BitIndex) -> BitIndex {
         if rank >= self.rank0 {
             return self.len;
         }
 
-        let mut super_block = self.select_blocks[rank / SELECT_BLOCK_SIZE].index_0;
+        let mut super_block = self.select_blocks[(rank / SELECT_BLOCK_SIZE) as usize].index_0;
 
         if self.super_blocks.len() > (super_block + 1)
             && self.super_blocks[super_block + 1].zeros <= rank
@@ -32,10 +32,10 @@ impl super::RsVec {
 
         rank -= self.super_blocks[super_block].zeros;
 
-        let mut block_index = super_block * (SUPER_BLOCK_SIZE / BLOCK_SIZE);
+        let mut block_index = super_block * (SUPER_BLOCK_SIZE / BLOCK_SIZE) as usize;
         self.search_block0(rank, &mut block_index);
 
-        rank -= self.blocks[block_index].zeros as usize;
+        rank -= self.blocks[block_index].zeros as BitIndex;
 
         self.search_word_in_block0(rank, block_index)
     }
@@ -56,7 +56,7 @@ impl super::RsVec {
         target_feature = "avx512bw",
     ))]
     #[inline(always)]
-    pub(super) fn search_block0(&self, rank: usize, block_index: &mut usize) {
+    pub(super) fn search_block0(&self, rank: BitIndex, block_index: &mut usize) {
         use std::arch::x86_64::{_mm256_cmpgt_epu16_mask, _mm256_loadu_epi16, _mm256_set1_epi16};
 
         if self.blocks.len() > *block_index + (SUPER_BLOCK_SIZE / BLOCK_SIZE) {
@@ -93,25 +93,25 @@ impl super::RsVec {
         target_feature = "avx512bw",
     )))]
     #[inline(always)]
-    pub(super) fn search_block0(&self, rank: usize, block_index: &mut usize) {
+    pub(super) fn search_block0(&self, rank: BitIndex, block_index: &mut usize) {
         self.search_block0_naive(rank, block_index);
     }
 
     #[inline(always)]
-    fn search_block0_naive(&self, rank: usize, block_index: &mut usize) {
+    fn search_block0_naive(&self, rank: BitIndex, block_index: &mut usize) {
         // full binary search for block that contains the rank, manually loop-unrolled, because
         // LLVM doesn't do it for us, but it gains just under 20% performance
 
         // this code relies on the fact that BLOCKS_PER_SUPERBLOCK blocks are in one superblock
         debug_assert!(
-            SUPER_BLOCK_SIZE / BLOCK_SIZE == BLOCKS_PER_SUPERBLOCK,
+            (SUPER_BLOCK_SIZE / BLOCK_SIZE) as usize == BLOCKS_PER_SUPERBLOCK,
             "change unroll constant to {}",
             64 - (SUPER_BLOCK_SIZE / BLOCK_SIZE).leading_zeros() - 1
         );
         unroll!(4,
-            |boundary = { (SUPER_BLOCK_SIZE / BLOCK_SIZE) / 2}|
+            |boundary = { (SUPER_BLOCK_SIZE / BLOCK_SIZE) as usize / 2}|
                 // do not use select_unpredictable here, it degrades performance
-                if self.blocks.len() > *block_index + boundary && rank >= self.blocks[*block_index + boundary].zeros as usize {
+                if self.blocks.len() > *block_index + boundary && rank >= self.blocks[*block_index + boundary].zeros as BitIndex {
                     *block_index += boundary;
                 },
             boundary /= 2);
@@ -126,7 +126,7 @@ impl super::RsVec {
     /// * `block_index` - the index of the block to search in, this is the block in the blocks
     ///   vector that contains the rank
     #[inline(always)]
-    pub(super) fn search_word_in_block0(&self, mut rank: usize, block_index: usize) -> usize {
+    pub(super) fn search_word_in_block0(&self, mut rank: BitIndex, block_index: usize) -> BitIndex {
         // linear search for word that contains the rank. Binary search is not possible here,
         // because we don't have accumulated popcounts for the words. We use pdep to find the
         // position of the rank-th zero bit in the word, if the word contains enough zeros, otherwise
@@ -134,24 +134,24 @@ impl super::RsVec {
         let mut index_counter = 0;
         debug_assert!(BLOCK_SIZE / WORD_SIZE == 8, "change unroll constant");
         unroll!(7, |n = {0}| {
-                    let word = self.data[block_index * BLOCK_SIZE / WORD_SIZE + n];
-                    if (word.count_zeros() as usize) <= rank {
-                        rank -= word.count_zeros() as usize;
+                    let word = self.data[block_index * (BLOCK_SIZE / WORD_SIZE) as usize + n];
+                    if (word.count_zeros() as BitIndex) <= rank {
+                        rank -= word.count_zeros() as BitIndex;
                         index_counter += WORD_SIZE;
                     } else {
-                        return block_index * BLOCK_SIZE
+                        return block_index as BitIndex * BLOCK_SIZE
                             + index_counter
-                            + (1 << rank).pdep(!word).trailing_zeros() as usize;
+                            + (1 << rank).pdep(!word).trailing_zeros() as BitIndex;
                     }
                 }, n += 1);
 
         // the last word must contain the rank-th zero bit, otherwise the rank is outside the
         // block, and thus outside the bitvector
-        block_index * BLOCK_SIZE
+        block_index as BitIndex * BLOCK_SIZE
             + index_counter
             + (1 << rank)
-                .pdep(!self.data[block_index * BLOCK_SIZE / WORD_SIZE + 7])
-                .trailing_zeros() as usize
+                .pdep(!self.data[block_index * (BLOCK_SIZE / WORD_SIZE) as usize + 7])
+                .trailing_zeros() as BitIndex
     }
 
     /// Search for the superblock that contains the rank.
@@ -162,8 +162,8 @@ impl super::RsVec {
     ///   superblock in the ``select_blocks`` vector that contains the rank
     /// * `rank` - the rank to search for
     #[inline(always)]
-    pub(super) fn search_super_block0(&self, mut super_block: usize, rank: usize) -> usize {
-        let mut upper_bound = self.select_blocks[rank / SELECT_BLOCK_SIZE + 1].index_0;
+    pub(super) fn search_super_block0(&self, mut super_block: usize, rank: BitIndex) -> usize {
+        let mut upper_bound = self.select_blocks[(rank / SELECT_BLOCK_SIZE + 1) as usize].index_0;
 
         while upper_bound - super_block > 8 {
             let middle = super_block + ((upper_bound - super_block) >> 1);
@@ -192,31 +192,31 @@ impl super::RsVec {
     /// If the rank is larger than the number of 1-bits in the bit-vector, the vector length is returned.
     #[must_use]
     #[allow(clippy::assertions_on_constants)]
-    pub fn select1(&self, mut rank: usize) -> usize {
+    pub fn select1(&self, mut rank: BitIndex) -> BitIndex {
         if rank >= self.rank1 {
             return self.len;
         }
 
-        let mut super_block =
-            self.select_blocks[rank / crate::bit_vec::fast_rs_vec::SELECT_BLOCK_SIZE].index_1;
+        let mut super_block = self.select_blocks[(rank / SELECT_BLOCK_SIZE) as usize].index_1;
 
         if self.super_blocks.len() > (super_block + 1)
-            && ((super_block + 1) * SUPER_BLOCK_SIZE - self.super_blocks[super_block + 1].zeros)
+            && ((super_block + 1) as BitIndex * SUPER_BLOCK_SIZE
+                - self.super_blocks[super_block + 1].zeros)
                 <= rank
         {
             super_block = self.search_super_block1(super_block, rank);
         }
 
-        rank -= (super_block) * SUPER_BLOCK_SIZE - self.super_blocks[super_block].zeros;
+        rank -= super_block as BitIndex * SUPER_BLOCK_SIZE - self.super_blocks[super_block].zeros;
 
         // full binary search for block that contains the rank, manually loop-unrolled, because
         // LLVM doesn't do it for us, but it gains just under 20% performance
-        let block_at_super_block = super_block * (SUPER_BLOCK_SIZE / BLOCK_SIZE);
+        let block_at_super_block = super_block * (SUPER_BLOCK_SIZE / BLOCK_SIZE) as usize;
         let mut block_index = block_at_super_block;
         self.search_block1(rank, block_at_super_block, &mut block_index);
 
-        rank -= (block_index - block_at_super_block) * BLOCK_SIZE
-            - self.blocks[block_index].zeros as usize;
+        rank -= (block_index - block_at_super_block) as BitIndex * BLOCK_SIZE
+            - self.blocks[block_index].zeros as BitIndex;
 
         self.search_word_in_block1(rank, block_index)
     }
@@ -240,7 +240,7 @@ impl super::RsVec {
     #[inline(always)]
     pub(super) fn search_block1(
         &self,
-        rank: usize,
+        rank: BitIndex,
         block_at_super_block: usize,
         block_index: &mut usize,
     ) {
@@ -307,7 +307,7 @@ impl super::RsVec {
     #[inline(always)]
     pub(super) fn search_block1(
         &self,
-        rank: usize,
+        rank: BitIndex,
         block_at_super_block: usize,
         block_index: &mut usize,
     ) {
@@ -317,7 +317,7 @@ impl super::RsVec {
     #[inline(always)]
     fn search_block1_naive(
         &self,
-        rank: usize,
+        rank: BitIndex,
         block_at_super_block: usize,
         block_index: &mut usize,
     ) {
@@ -326,14 +326,14 @@ impl super::RsVec {
 
         // this code relies on the fact that BLOCKS_PER_SUPERBLOCK blocks are in one superblock
         debug_assert!(
-            SUPER_BLOCK_SIZE / BLOCK_SIZE == BLOCKS_PER_SUPERBLOCK,
+            (SUPER_BLOCK_SIZE / BLOCK_SIZE) as usize == BLOCKS_PER_SUPERBLOCK,
             "change unroll constant to {}",
             64 - (SUPER_BLOCK_SIZE / BLOCK_SIZE).leading_zeros() - 1
         );
         unroll!(4,
-            |boundary = { (SUPER_BLOCK_SIZE / BLOCK_SIZE) / 2}|
+            |boundary = { (SUPER_BLOCK_SIZE / BLOCK_SIZE) as usize / 2}|
                 // do not use select_unpredictable here, it degrades performance
-                if self.blocks.len() > *block_index + boundary && rank >= (*block_index + boundary - block_at_super_block) * BLOCK_SIZE - self.blocks[*block_index + boundary].zeros as usize {
+                if self.blocks.len() > *block_index + boundary && rank >= (*block_index + boundary - block_at_super_block) as BitIndex * BLOCK_SIZE - self.blocks[*block_index + boundary].zeros as BitIndex {
                     *block_index += boundary;
                 },
             boundary /= 2);
@@ -348,7 +348,7 @@ impl super::RsVec {
     /// * `block_index` - the index of the block to search in, this is the block in the blocks
     ///   vector that contains the rank
     #[inline(always)]
-    pub(super) fn search_word_in_block1(&self, mut rank: usize, block_index: usize) -> usize {
+    pub(super) fn search_word_in_block1(&self, mut rank: BitIndex, block_index: usize) -> BitIndex {
         // linear search for word that contains the rank. Binary search is not possible here,
         // because we don't have accumulated popcounts for the words. We use pdep to find the
         // position of the rank-th zero bit in the word, if the word contains enough zeros, otherwise
@@ -356,24 +356,24 @@ impl super::RsVec {
         let mut index_counter = 0;
         debug_assert!(BLOCK_SIZE / WORD_SIZE == 8, "change unroll constant");
         unroll!(7, |n = {0}| {
-            let word = self.data[block_index * BLOCK_SIZE / WORD_SIZE + n];
-            if (word.count_ones() as usize) <= rank {
-                rank -= word.count_ones() as usize;
+            let word = self.data[block_index * (BLOCK_SIZE / WORD_SIZE) as usize + n];
+            if (word.count_ones() as BitIndex) <= rank {
+                rank -= word.count_ones() as BitIndex;
                 index_counter += WORD_SIZE;
             } else {
-                return block_index * BLOCK_SIZE
+                return block_index as BitIndex * BLOCK_SIZE
                     + index_counter
-                    + (1 << rank).pdep(word).trailing_zeros() as usize;
+                    + (1 << rank).pdep(word).trailing_zeros() as BitIndex;
             }
         }, n += 1);
 
         // the last word must contain the rank-th zero bit, otherwise the rank is outside of the
         // block, and thus outside of the bitvector
-        block_index * BLOCK_SIZE
+        block_index as BitIndex * BLOCK_SIZE
             + index_counter
             + (1 << rank)
-                .pdep(self.data[block_index * BLOCK_SIZE / WORD_SIZE + 7])
-                .trailing_zeros() as usize
+                .pdep(self.data[block_index * (BLOCK_SIZE / WORD_SIZE) as usize + 7])
+                .trailing_zeros() as BitIndex
     }
 
     /// Search for the superblock that contains the rank.
@@ -384,14 +384,16 @@ impl super::RsVec {
     ///   superblock in the ``select_blocks`` vector that contains the rank
     /// * `rank` - the rank to search for
     #[inline(always)]
-    pub(super) fn search_super_block1(&self, mut super_block: usize, rank: usize) -> usize {
-        let mut upper_bound = self.select_blocks[rank / SELECT_BLOCK_SIZE + 1].index_1;
+    pub(super) fn search_super_block1(&self, mut super_block: usize, rank: BitIndex) -> usize {
+        let mut upper_bound = self.select_blocks[(rank / SELECT_BLOCK_SIZE + 1) as usize].index_1;
 
         // binary search for superblock that contains the rank
         while upper_bound - super_block > 8 {
             let middle = super_block + ((upper_bound - super_block) >> 1);
             // using select_unpredictable does nothing here, likely because the search isn't hot
-            if ((middle + 1) * SUPER_BLOCK_SIZE - self.super_blocks[middle].zeros) <= rank {
+            if ((middle + 1) as BitIndex * SUPER_BLOCK_SIZE - self.super_blocks[middle].zeros)
+                <= rank
+            {
                 super_block = middle;
             } else {
                 upper_bound = middle;
@@ -399,7 +401,8 @@ impl super::RsVec {
         }
         // linear search for superblock that contains the rank
         while self.super_blocks.len() > (super_block + 1)
-            && ((super_block + 1) * SUPER_BLOCK_SIZE - self.super_blocks[super_block + 1].zeros)
+            && ((super_block + 1) as BitIndex * SUPER_BLOCK_SIZE
+                - self.super_blocks[super_block + 1].zeros)
                 <= rank
         {
             super_block += 1;

--- a/src/bit_vec/fast_rs_vec/select.rs
+++ b/src/bit_vec/fast_rs_vec/select.rs
@@ -258,6 +258,7 @@ impl super::RsVec {
             );
 
             unsafe {
+                #[allow(clippy::cast_possible_truncation)] // false positive because constants
                 let bit_nums = _mm256_set_epi16(
                     (15 * BLOCK_SIZE) as i16,
                     (14 * BLOCK_SIZE) as i16,
@@ -274,7 +275,7 @@ impl super::RsVec {
                     (3 * BLOCK_SIZE) as i16,
                     (2 * BLOCK_SIZE) as i16,
                     (1 * BLOCK_SIZE) as i16,
-                    (0 * BLOCK_SIZE) as i16,
+                    0i16,
                 );
 
                 let blocks = _mm256_loadu_epi16(self.blocks[*block_index..].as_ptr() as *const i16);

--- a/src/bit_vec/fast_rs_vec/select.rs
+++ b/src/bit_vec/fast_rs_vec/select.rs
@@ -7,7 +7,7 @@ use crate::util::unroll;
 
 /// A safety constant for assertions to make sure that the block size doesn't change without
 /// adjusting the code.
-const BLOCKS_PER_SUPERBLOCK: usize = 16;
+const BLOCKS_PER_SUPERBLOCK: u64 = 16;
 
 impl super::RsVec {
     /// Return the position of the 0-bit with the given rank. See `rank0`.
@@ -59,7 +59,7 @@ impl super::RsVec {
     pub(super) fn search_block0(&self, rank: u64, block_index: &mut usize) {
         use std::arch::x86_64::{_mm256_cmpgt_epu16_mask, _mm256_loadu_epi16, _mm256_set1_epi16};
 
-        if self.blocks.len() > *block_index + (SUPER_BLOCK_SIZE / BLOCK_SIZE) {
+        if self.blocks.len() > *block_index + (SUPER_BLOCK_SIZE / BLOCK_SIZE) as usize {
             debug_assert!(
                 SUPER_BLOCK_SIZE / BLOCK_SIZE == BLOCKS_PER_SUPERBLOCK,
                 "change unroll constant to {}",
@@ -104,7 +104,7 @@ impl super::RsVec {
 
         // this code relies on the fact that BLOCKS_PER_SUPERBLOCK blocks are in one superblock
         debug_assert!(
-            (SUPER_BLOCK_SIZE / BLOCK_SIZE) as usize == BLOCKS_PER_SUPERBLOCK,
+            (SUPER_BLOCK_SIZE / BLOCK_SIZE) == BLOCKS_PER_SUPERBLOCK,
             "change unroll constant to {}",
             64 - (SUPER_BLOCK_SIZE / BLOCK_SIZE).leading_zeros() - 1
         );
@@ -249,7 +249,7 @@ impl super::RsVec {
             _mm256_sub_epi16,
         };
 
-        if self.blocks.len() > *block_index + BLOCKS_PER_SUPERBLOCK {
+        if self.blocks.len() > *block_index + BLOCKS_PER_SUPERBLOCK as usize {
             debug_assert!(
                 SUPER_BLOCK_SIZE / BLOCK_SIZE == BLOCKS_PER_SUPERBLOCK,
                 "change unroll constant to {}",
@@ -321,7 +321,7 @@ impl super::RsVec {
 
         // this code relies on the fact that BLOCKS_PER_SUPERBLOCK blocks are in one superblock
         debug_assert!(
-            (SUPER_BLOCK_SIZE / BLOCK_SIZE) as usize == BLOCKS_PER_SUPERBLOCK,
+            (SUPER_BLOCK_SIZE / BLOCK_SIZE) == BLOCKS_PER_SUPERBLOCK,
             "change unroll constant to {}",
             64 - (SUPER_BLOCK_SIZE / BLOCK_SIZE).leading_zeros() - 1
         );

--- a/src/bit_vec/fast_rs_vec/select.rs
+++ b/src/bit_vec/fast_rs_vec/select.rs
@@ -162,6 +162,7 @@ impl super::RsVec {
     ///   superblock in the ``select_blocks`` vector that contains the rank
     /// * `rank` - the rank to search for
     #[inline(always)]
+    #[allow(clippy::cast_possible_truncation)] // safe due to the division
     pub(super) fn search_super_block0(&self, mut super_block: usize, rank: u64) -> usize {
         let mut upper_bound = self.select_blocks[(rank / SELECT_BLOCK_SIZE + 1) as usize].index_0;
 
@@ -379,6 +380,7 @@ impl super::RsVec {
     ///   superblock in the ``select_blocks`` vector that contains the rank
     /// * `rank` - the rank to search for
     #[inline(always)]
+    #[allow(clippy::cast_possible_truncation)] // safe due to the division
     pub(super) fn search_super_block1(&self, mut super_block: usize, rank: u64) -> usize {
         let mut upper_bound = self.select_blocks[(rank / SELECT_BLOCK_SIZE + 1) as usize].index_1;
 

--- a/src/bit_vec/fast_rs_vec/tests.rs
+++ b/src/bit_vec/fast_rs_vec/tests.rs
@@ -23,7 +23,7 @@ fn test_random_data_rank() {
         6, 7,
     ]);
     let sample = Uniform::new(0, 2);
-    static LENGTH: BitIndex = 4 * SUPER_BLOCK_SIZE;
+    static LENGTH: u64 = 4 * SUPER_BLOCK_SIZE;
 
     for _ in 0..LENGTH {
         bv.append_bit(sample.sample(&mut rng));
@@ -46,13 +46,13 @@ fn test_random_data_rank() {
         let bit_index = rnd_index % WORD_SIZE;
 
         for v in data.iter().take(data_index) {
-            expected_rank1 += v.count_ones() as BitIndex;
-            expected_rank0 += v.count_zeros() as BitIndex;
+            expected_rank1 += v.count_ones() as u64;
+            expected_rank0 += v.count_zeros() as u64;
         }
 
         if bit_index > 0 {
-            expected_rank1 += (data[data_index] & ((1 << bit_index) - 1)).count_ones() as BitIndex;
-            expected_rank0 += (!data[data_index] & ((1 << bit_index) - 1)).count_ones() as BitIndex;
+            expected_rank1 += (data[data_index] & ((1 << bit_index) - 1)).count_ones() as u64;
+            expected_rank0 += (!data[data_index] & ((1 << bit_index) - 1)).count_ones() as u64;
         }
 
         assert_eq!(actual_rank1, expected_rank1);
@@ -205,7 +205,7 @@ fn test_only_ones_select() {
 
 #[test]
 fn random_data_select0() {
-    static LENGTH: BitIndex = 4 * SUPER_BLOCK_SIZE;
+    static LENGTH: u64 = 4 * SUPER_BLOCK_SIZE;
     let mut bv = BitVec::with_capacity(LENGTH);
     let mut rng = StdRng::from_seed([
         0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5,
@@ -231,7 +231,7 @@ fn random_data_select0() {
 
         let mut index = 0;
         loop {
-            let zeros = data[index].count_zeros() as BitIndex;
+            let zeros = data[index].count_zeros() as u64;
             if rank_counter + zeros > rnd_rank0 {
                 break;
             } else {
@@ -260,7 +260,7 @@ fn random_data_select0() {
 
 #[test]
 fn random_data_select1() {
-    static LENGTH: BitIndex = 4 * SUPER_BLOCK_SIZE;
+    static LENGTH: u64 = 4 * SUPER_BLOCK_SIZE;
     let mut bv = BitVec::with_capacity(LENGTH);
     let mut rng = StdRng::from_seed([
         0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5,
@@ -286,7 +286,7 @@ fn random_data_select1() {
 
         let mut index = 0;
         loop {
-            let ones = data[index].count_ones() as BitIndex;
+            let ones = data[index].count_ones() as u64;
             if rank_counter + ones > rnd_rank1 {
                 break;
             } else {
@@ -1254,7 +1254,7 @@ fn test_random_data_iter_both_ends() {
 // test a randomly generated bit vector for correct values in blocks
 #[test]
 fn test_block_layout() {
-    static LENGTH: BitIndex = 4 * SUPER_BLOCK_SIZE;
+    static LENGTH: u64 = 4 * SUPER_BLOCK_SIZE;
     let mut bv = BitVec::with_capacity(LENGTH);
     let mut rng = StdRng::from_seed([
         0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5,
@@ -1293,7 +1293,7 @@ fn test_block_layout() {
 // Github issue https://github.com/Cydhra/vers/issues/6 regression test
 #[test]
 fn test_iter1_regression_i6() {
-    static LENGTH: BitIndex = 4 * SUPER_BLOCK_SIZE;
+    static LENGTH: u64 = 4 * SUPER_BLOCK_SIZE;
     let mut bv = BitVec::with_capacity(LENGTH);
     let mut rng = StdRng::from_seed([
         0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5,

--- a/src/bit_vec/fast_rs_vec/tests.rs
+++ b/src/bit_vec/fast_rs_vec/tests.rs
@@ -23,7 +23,7 @@ fn test_random_data_rank() {
         6, 7,
     ]);
     let sample = Uniform::new(0, 2);
-    static LENGTH: usize = 4 * SUPER_BLOCK_SIZE;
+    static LENGTH: BitIndex = 4 * SUPER_BLOCK_SIZE;
 
     for _ in 0..LENGTH {
         bv.append_bit(sample.sample(&mut rng));
@@ -42,17 +42,17 @@ fn test_random_data_rank() {
         let mut expected_rank1 = 0;
         let mut expected_rank0 = 0;
 
-        let data_index = rnd_index / WORD_SIZE;
+        let data_index = (rnd_index / WORD_SIZE) as usize;
         let bit_index = rnd_index % WORD_SIZE;
 
         for v in data.iter().take(data_index) {
-            expected_rank1 += v.count_ones() as usize;
-            expected_rank0 += v.count_zeros() as usize;
+            expected_rank1 += v.count_ones() as BitIndex;
+            expected_rank0 += v.count_zeros() as BitIndex;
         }
 
         if bit_index > 0 {
-            expected_rank1 += (data[data_index] & ((1 << bit_index) - 1)).count_ones() as usize;
-            expected_rank0 += (!data[data_index] & ((1 << bit_index) - 1)).count_ones() as usize;
+            expected_rank1 += (data[data_index] & ((1 << bit_index) - 1)).count_ones() as BitIndex;
+            expected_rank0 += (!data[data_index] & ((1 << bit_index) - 1)).count_ones() as BitIndex;
         }
 
         assert_eq!(actual_rank1, expected_rank1);
@@ -205,13 +205,13 @@ fn test_only_ones_select() {
 
 #[test]
 fn random_data_select0() {
+    static LENGTH: BitIndex = 4 * SUPER_BLOCK_SIZE;
     let mut bv = BitVec::with_capacity(LENGTH);
     let mut rng = StdRng::from_seed([
         0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5,
         6, 7,
     ]);
     let sample = Uniform::new(0, 2);
-    static LENGTH: usize = 4 * SUPER_BLOCK_SIZE;
 
     for _ in 0..LENGTH {
         bv.append_bit_u8(sample.sample(&mut rng) as u8);
@@ -231,7 +231,7 @@ fn random_data_select0() {
 
         let mut index = 0;
         loop {
-            let zeros = data[index].count_zeros() as usize;
+            let zeros = data[index].count_zeros() as BitIndex;
             if rank_counter + zeros > rnd_rank0 {
                 break;
             } else {
@@ -260,13 +260,13 @@ fn random_data_select0() {
 
 #[test]
 fn random_data_select1() {
+    static LENGTH: BitIndex = 4 * SUPER_BLOCK_SIZE;
     let mut bv = BitVec::with_capacity(LENGTH);
     let mut rng = StdRng::from_seed([
         0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5,
         6, 7,
     ]);
     let sample = Uniform::new(0, 2);
-    static LENGTH: usize = 4 * SUPER_BLOCK_SIZE;
 
     for _ in 0..LENGTH {
         bv.append_bit_u8(sample.sample(&mut rng) as u8);
@@ -286,7 +286,7 @@ fn random_data_select1() {
 
         let mut index = 0;
         loop {
-            let ones = data[index].count_ones() as usize;
+            let ones = data[index].count_ones() as BitIndex;
             if rank_counter + ones > rnd_rank1 {
                 break;
             } else {
@@ -1211,8 +1211,8 @@ fn test_random_data_iter_both_ends() {
                 }
                 let bv = RsVec::from_bit_vec(bv);
 
-                let mut zeros = Vec::with_capacity(bv.rank0);
-                let mut ones = Vec::with_capacity(bv.rank1);
+                let mut zeros = Vec::with_capacity(bv.rank0 as usize);
+                let mut ones = Vec::with_capacity(bv.rank1 as usize);
 
                 let mut iter0 = bv.iter0();
                 let mut iter1 = bv.iter1();
@@ -1226,7 +1226,7 @@ fn test_random_data_iter_both_ends() {
                 }
                 zeros.sort();
                 zeros.dedup();
-                assert_eq!(zeros.len(), bv.rank0);
+                assert_eq!(zeros.len() as u64, bv.rank0);
 
                 for _ in 0..bv.rank1 {
                     ones.push(if sample.sample(&mut rng) < 50 {
@@ -1237,7 +1237,7 @@ fn test_random_data_iter_both_ends() {
                 }
                 ones.sort();
                 ones.dedup();
-                assert_eq!(ones.len(), bv.rank1);
+                assert_eq!(ones.len() as u64, bv.rank1);
 
                 for idx in ones {
                     assert_eq!(bv.get(idx), Some(1), "bit {} is not 1", idx);
@@ -1254,7 +1254,7 @@ fn test_random_data_iter_both_ends() {
 // test a randomly generated bit vector for correct values in blocks
 #[test]
 fn test_block_layout() {
-    static LENGTH: usize = 4 * SUPER_BLOCK_SIZE;
+    static LENGTH: BitIndex = 4 * SUPER_BLOCK_SIZE;
     let mut bv = BitVec::with_capacity(LENGTH);
     let mut rng = StdRng::from_seed([
         0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5,
@@ -1271,7 +1271,7 @@ fn test_block_layout() {
 
     let mut zero_counter = 0u32;
     for (block_index, block) in bv.blocks.iter().enumerate() {
-        if block_index % (SUPER_BLOCK_SIZE / BLOCK_SIZE) == 0 {
+        if block_index % (SUPER_BLOCK_SIZE / BLOCK_SIZE) as usize == 0 {
             zero_counter = 0;
         }
         assert_eq!(
@@ -1281,9 +1281,9 @@ fn test_block_layout() {
             block_index,
             bv.blocks.len()
         );
-        for word in bv.data[block_index * BLOCK_SIZE / WORD_SIZE..]
+        for word in bv.data[block_index * (BLOCK_SIZE / WORD_SIZE) as usize..]
             .iter()
-            .take(BLOCK_SIZE / WORD_SIZE)
+            .take((BLOCK_SIZE / WORD_SIZE) as usize)
         {
             zero_counter += word.count_zeros();
         }
@@ -1293,7 +1293,7 @@ fn test_block_layout() {
 // Github issue https://github.com/Cydhra/vers/issues/6 regression test
 #[test]
 fn test_iter1_regression_i6() {
-    static LENGTH: usize = 4 * SUPER_BLOCK_SIZE;
+    static LENGTH: BitIndex = 4 * SUPER_BLOCK_SIZE;
     let mut bv = BitVec::with_capacity(LENGTH);
     let mut rng = StdRng::from_seed([
         0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5,
@@ -1319,7 +1319,7 @@ fn test_iter1_regression_i6() {
 
     let mut all_bits: Vec<_> = bv.iter0().chain(bv.iter1()).collect();
     all_bits.sort();
-    assert_eq!(all_bits.len(), LENGTH);
+    assert_eq!(all_bits.len() as u64, LENGTH);
 }
 
 // Github issue https://github.com/Cydhra/vers/issues/8 regression test

--- a/src/bit_vec/mask.rs
+++ b/src/bit_vec/mask.rs
@@ -138,6 +138,7 @@ where
     #[must_use]
     #[allow(clippy::inline_always)]
     #[allow(clippy::comparison_chain)] // rust-clippy #5354
+    #[allow(clippy::cast_possible_truncation)] // safe due to the division
     #[inline]
     pub fn get_bits_unchecked(&self, pos: u64, len: u64) -> u64 {
         debug_assert!(len <= WORD_SIZE);

--- a/src/bit_vec/mask.rs
+++ b/src/bit_vec/mask.rs
@@ -2,7 +2,7 @@
 //! of `BitVec` but applies a bit-mask during the operation. The struct is created through
 //! [`BitVec::mask_xor`], [`BitVec::mask_and`], [`BitVec::mask_or`], or [`BitVec::mask_custom`].
 
-use super::WORD_SIZE;
+use super::{BitIndex, WORD_SIZE};
 use crate::BitVec;
 
 /// A bit vector that is masked with another bit vector via a masking function. Offers the same
@@ -48,7 +48,7 @@ where
     /// If the position is larger than the length of the vector, None is returned.
     #[inline]
     #[must_use]
-    pub fn get(&self, pos: usize) -> Option<u64> {
+    pub fn get(&self, pos: BitIndex) -> Option<u64> {
         if pos >= self.vec.len {
             None
         } else {
@@ -67,10 +67,10 @@ where
     /// [`get`]: MaskedBitVec::get
     #[inline]
     #[must_use]
-    pub fn get_unchecked(&self, pos: usize) -> u64 {
+    pub fn get_unchecked(&self, pos: BitIndex) -> u64 {
         ((self.bin_op)(
-            self.vec.data[pos / WORD_SIZE],
-            self.mask.data[pos / WORD_SIZE],
+            self.vec.data[(pos / WORD_SIZE) as usize],
+            self.mask.data[(pos / WORD_SIZE) as usize],
         ) >> (pos % WORD_SIZE))
             & 1
     }
@@ -79,7 +79,7 @@ where
     /// If the position is larger than the length of the vector, None is returned.
     #[inline]
     #[must_use]
-    pub fn is_bit_set(&self, pos: usize) -> Option<bool> {
+    pub fn is_bit_set(&self, pos: BitIndex) -> Option<bool> {
         if pos >= self.vec.len {
             None
         } else {
@@ -97,7 +97,7 @@ where
     /// [`is_bit_set`]: MaskedBitVec::is_bit_set
     #[inline]
     #[must_use]
-    pub fn is_bit_set_unchecked(&self, pos: usize) -> bool {
+    pub fn is_bit_set_unchecked(&self, pos: BitIndex) -> bool {
         self.get_unchecked(pos) != 0
     }
 
@@ -108,7 +108,7 @@ where
     /// If the length of the query is larger than 64, None is returned.
     #[inline]
     #[must_use]
-    pub fn get_bits(&self, pos: usize, len: usize) -> Option<u64> {
+    pub fn get_bits(&self, pos: BitIndex, len: u64) -> Option<u64> {
         if len > WORD_SIZE || len == 0 {
             return None;
         }
@@ -139,11 +139,11 @@ where
     #[allow(clippy::inline_always)]
     #[allow(clippy::comparison_chain)] // rust-clippy #5354
     #[inline]
-    pub fn get_bits_unchecked(&self, pos: usize, len: usize) -> u64 {
+    pub fn get_bits_unchecked(&self, pos: BitIndex, len: u64) -> u64 {
         debug_assert!(len <= WORD_SIZE);
         let partial_word = (self.bin_op)(
-            self.vec.data[pos / WORD_SIZE],
-            self.mask.data[pos / WORD_SIZE],
+            self.vec.data[(pos / WORD_SIZE) as usize],
+            self.mask.data[(pos / WORD_SIZE) as usize],
         ) >> (pos % WORD_SIZE);
 
         if pos % WORD_SIZE + len == WORD_SIZE {
@@ -152,8 +152,8 @@ where
             partial_word & ((1 << (len % WORD_SIZE)) - 1)
         } else {
             let next_half = (self.bin_op)(
-                self.vec.data[pos / WORD_SIZE + 1],
-                self.mask.data[pos / WORD_SIZE + 1],
+                self.vec.data[(pos / WORD_SIZE + 1) as usize],
+                self.mask.data[(pos / WORD_SIZE + 1) as usize],
             ) << (WORD_SIZE - pos % WORD_SIZE);
 
             (partial_word | next_half) & ((1 << (len % WORD_SIZE)) - 1)
@@ -174,10 +174,10 @@ where
     #[inline]
     #[must_use]
     #[allow(clippy::missing_panics_doc)] // can't panic because of bounds check
-    pub fn count_ones(&self) -> u64 {
+    pub fn count_ones(&self) -> BitIndex {
         let mut ones = self
             .iter_limbs()
-            .take(self.vec.len / WORD_SIZE)
+            .take((self.vec.len / WORD_SIZE) as usize)
             .map(|limb| u64::from(limb.count_ones()))
             .sum();
         if self.vec.len % WORD_SIZE > 0 {

--- a/src/bit_vec/mask.rs
+++ b/src/bit_vec/mask.rs
@@ -180,7 +180,7 @@ where
             .take(self.vec.len / WORD_SIZE)
             .map(|limb| u64::from(limb.count_ones()))
             .sum();
-        if self.vec.len % WORD_SIZE > 0 {
+        if !self.vec.len.is_multiple_of(WORD_SIZE) {
             ones += u64::from(
                 ((self.bin_op)(
                     *self.vec.data.last().unwrap(),

--- a/src/bit_vec/mask.rs
+++ b/src/bit_vec/mask.rs
@@ -167,7 +167,7 @@ where
     #[inline]
     #[must_use]
     pub fn count_zeros(&self) -> u64 {
-        self.vec.len as u64 - self.count_ones()
+        self.vec.len - self.count_ones()
     }
 
     /// Return the number of ones in the masked bit vector.

--- a/src/bit_vec/mask.rs
+++ b/src/bit_vec/mask.rs
@@ -2,7 +2,7 @@
 //! of `BitVec` but applies a bit-mask during the operation. The struct is created through
 //! [`BitVec::mask_xor`], [`BitVec::mask_and`], [`BitVec::mask_or`], or [`BitVec::mask_custom`].
 
-use super::{BitIndex, WORD_SIZE};
+use super::WORD_SIZE;
 use crate::BitVec;
 
 /// A bit vector that is masked with another bit vector via a masking function. Offers the same
@@ -48,7 +48,7 @@ where
     /// If the position is larger than the length of the vector, None is returned.
     #[inline]
     #[must_use]
-    pub fn get(&self, pos: BitIndex) -> Option<u64> {
+    pub fn get(&self, pos: u64) -> Option<u64> {
         if pos >= self.vec.len {
             None
         } else {
@@ -67,7 +67,7 @@ where
     /// [`get`]: MaskedBitVec::get
     #[inline]
     #[must_use]
-    pub fn get_unchecked(&self, pos: BitIndex) -> u64 {
+    pub fn get_unchecked(&self, pos: u64) -> u64 {
         ((self.bin_op)(
             self.vec.data[(pos / WORD_SIZE) as usize],
             self.mask.data[(pos / WORD_SIZE) as usize],
@@ -79,7 +79,7 @@ where
     /// If the position is larger than the length of the vector, None is returned.
     #[inline]
     #[must_use]
-    pub fn is_bit_set(&self, pos: BitIndex) -> Option<bool> {
+    pub fn is_bit_set(&self, pos: u64) -> Option<bool> {
         if pos >= self.vec.len {
             None
         } else {
@@ -97,7 +97,7 @@ where
     /// [`is_bit_set`]: MaskedBitVec::is_bit_set
     #[inline]
     #[must_use]
-    pub fn is_bit_set_unchecked(&self, pos: BitIndex) -> bool {
+    pub fn is_bit_set_unchecked(&self, pos: u64) -> bool {
         self.get_unchecked(pos) != 0
     }
 
@@ -108,7 +108,7 @@ where
     /// If the length of the query is larger than 64, None is returned.
     #[inline]
     #[must_use]
-    pub fn get_bits(&self, pos: BitIndex, len: u64) -> Option<u64> {
+    pub fn get_bits(&self, pos: u64, len: u64) -> Option<u64> {
         if len > WORD_SIZE || len == 0 {
             return None;
         }
@@ -139,7 +139,7 @@ where
     #[allow(clippy::inline_always)]
     #[allow(clippy::comparison_chain)] // rust-clippy #5354
     #[inline]
-    pub fn get_bits_unchecked(&self, pos: BitIndex, len: u64) -> u64 {
+    pub fn get_bits_unchecked(&self, pos: u64, len: u64) -> u64 {
         debug_assert!(len <= WORD_SIZE);
         let partial_word = (self.bin_op)(
             self.vec.data[(pos / WORD_SIZE) as usize],
@@ -174,7 +174,7 @@ where
     #[inline]
     #[must_use]
     #[allow(clippy::missing_panics_doc)] // can't panic because of bounds check
-    pub fn count_ones(&self) -> BitIndex {
+    pub fn count_ones(&self) -> u64 {
         let mut ones = self
             .iter_limbs()
             .take((self.vec.len / WORD_SIZE) as usize)

--- a/src/bit_vec/mod.rs
+++ b/src/bit_vec/mod.rs
@@ -1374,7 +1374,7 @@ impl Eq for BitVec {}
 
 impl Hash for BitVec {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        state.write_usize(self.len);
+        state.write_u64(self.len);
         if self.len > 0 {
             self.data[0..self.data.len() - 1]
                 .iter()

--- a/src/bit_vec/mod.rs
+++ b/src/bit_vec/mod.rs
@@ -1056,7 +1056,7 @@ impl BitVec {
     /// [`count_ones`]: BitVec::count_ones
     #[must_use]
     pub fn count_zeros(&self) -> u64 {
-        self.len as u64 - self.count_ones()
+        self.len - self.count_ones()
     }
 
     /// Mask this bit vector with another bitvector using bitwise or. The mask is applied lazily

--- a/src/bit_vec/mod.rs
+++ b/src/bit_vec/mod.rs
@@ -77,6 +77,7 @@ impl BitVec {
     #[must_use]
     pub fn with_capacity(capacity: u64) -> Self {
         Self {
+            #[allow(clippy::cast_possible_truncation)] // safe due to the division
             data: Vec::with_capacity((capacity / WORD_SIZE + 1) as usize),
             len: 0,
         }
@@ -86,6 +87,7 @@ impl BitVec {
     /// The length is measured in bits.
     #[must_use]
     pub fn from_zeros(len: u64) -> Self {
+        #[allow(clippy::cast_possible_truncation)] // safe due to the division
         let data = vec![0; len.div_ceil(WORD_SIZE) as usize];
         Self { data, len }
     }
@@ -95,6 +97,7 @@ impl BitVec {
     #[must_use]
     pub fn from_ones(len: u64) -> Self {
         // junk data is allowed to be any bit
+        #[allow(clippy::cast_possible_truncation)] // safe due to the division
         let data = vec![u64::MAX; len.div_ceil(WORD_SIZE) as usize];
         Self { data, len }
     }
@@ -531,6 +534,7 @@ impl BitVec {
             return;
         }
 
+        #[allow(clippy::cast_possible_truncation)] // safe due to the division
         let new_limb_count = (self.len - n).div_ceil(WORD_SIZE) as usize;
 
         // cut off limbs that we no longer need
@@ -738,6 +742,7 @@ impl BitVec {
     /// This function is guaranteed to reallocate the underlying vector at most once.
     pub fn extend_bitvec(&mut self, other: &Self) {
         // reserve space for the new bits, ensuring at most one re-allocation
+        #[allow(clippy::cast_possible_truncation)] // safe due to the division
         self.data
             .reserve((self.len + other.len).div_ceil(WORD_SIZE) as usize - self.data.len());
 

--- a/src/bit_vec/mod.rs
+++ b/src/bit_vec/mod.rs
@@ -87,7 +87,7 @@ impl BitVec {
     #[must_use]
     pub fn from_zeros(len: usize) -> Self {
         let mut data = vec![0; len / WORD_SIZE];
-        if len % WORD_SIZE != 0 {
+        if !len.is_multiple_of(WORD_SIZE) {
             data.push(0);
         }
         Self { data, len }
@@ -98,7 +98,7 @@ impl BitVec {
     #[must_use]
     pub fn from_ones(len: usize) -> Self {
         let mut data = vec![u64::MAX; len / WORD_SIZE];
-        if len % WORD_SIZE != 0 {
+        if !len.is_multiple_of(WORD_SIZE) {
             data.push((1 << (len % WORD_SIZE)) - 1);
         }
         Self { data, len }
@@ -500,7 +500,7 @@ impl BitVec {
     /// [`append_bit_u8`]: BitVec::append_bit_u8
     /// [`append_word`]: BitVec::append_word
     pub fn append(&mut self, bit: bool) {
-        if self.len % WORD_SIZE == 0 {
+        if self.len.is_multiple_of(WORD_SIZE) {
             self.data.push(0);
         }
         if bit {
@@ -574,7 +574,7 @@ impl BitVec {
     /// [`append_bit_u8`]: BitVec::append_bit_u8
     /// [`append_word`]: BitVec::append_word
     pub fn append_bit(&mut self, bit: u64) {
-        if self.len % WORD_SIZE == 0 {
+        if self.len.is_multiple_of(WORD_SIZE) {
             self.data.push(0);
         }
         if bit % 2 == 1 {
@@ -653,7 +653,7 @@ impl BitVec {
     /// [`append_bit_u16`]: BitVec::append_bit_u16
     /// [`append_bit_u8`]: BitVec::append_bit_u8
     pub fn append_word(&mut self, word: u64) {
-        if self.len % WORD_SIZE == 0 {
+        if self.len.is_multiple_of(WORD_SIZE) {
             self.data.push(word);
         } else {
             // zero out the unused bits before or-ing the new one, to ensure no garbage data remains
@@ -688,7 +688,7 @@ impl BitVec {
     pub fn append_bits(&mut self, bits: u64, len: usize) {
         assert!(len <= 64, "Cannot append more than 64 bits");
 
-        if self.len % WORD_SIZE == 0 {
+        if self.len.is_multiple_of(WORD_SIZE) {
             self.data.push(bits);
         } else {
             // zero out the unused bits before or-ing the new one, to ensure no garbage data remains
@@ -725,7 +725,7 @@ impl BitVec {
     /// [`append_bits`]: BitVec::append_bits
     /// [`drop_last`]: BitVec::drop_last
     pub fn append_bits_unchecked(&mut self, bits: u64, len: usize) {
-        if self.len % WORD_SIZE == 0 {
+        if self.len.is_multiple_of(WORD_SIZE) {
             self.data.push(bits);
         } else {
             self.data[self.len / WORD_SIZE] |= bits << (self.len % WORD_SIZE);
@@ -1043,7 +1043,7 @@ impl BitVec {
             .iter()
             .map(|limb| u64::from(limb.count_ones()))
             .sum();
-        if self.len % WORD_SIZE > 0 {
+        if !self.len.is_multiple_of(WORD_SIZE) {
             ones += u64::from(
                 (self.data.last().unwrap() & ((1 << (self.len % WORD_SIZE)) - 1)).count_ones(),
             );

--- a/src/bit_vec/mod.rs
+++ b/src/bit_vec/mod.rs
@@ -820,6 +820,8 @@ impl BitVec {
     /// assert_eq!(bv.get(1), Some(0));
     /// assert_eq!(bv.get(2), Some(1));
     /// ```
+    ///
+    /// [`get_unchecked`]: Self::get_unchecked
     #[must_use]
     pub fn get(&self, pos: usize) -> Option<u64> {
         if pos >= self.len {
@@ -1226,6 +1228,8 @@ impl BitVec {
     /// containing the original vector.
     ///
     /// See also: [`split_at_unchecked`]
+    ///
+    /// [`split_at_unchecked`]: Self::split_at_unchecked
     pub fn split_at(self, at: usize) -> Result<(Self, Self), Self> {
         if at > self.len {
             Err(self)
@@ -1241,6 +1245,8 @@ impl BitVec {
     /// If the index is larger than the length of the vector the function will panic or run
     /// out of memory.
     /// Use [`split_at`] to properly handle this case.
+    ///
+    /// [`split_at`]: Self::split_at
     #[must_use]
     pub fn split_at_unchecked(mut self, at: usize) -> (Self, Self) {
         let other_len = self.len - at;

--- a/src/bit_vec/mod.rs
+++ b/src/bit_vec/mod.rs
@@ -1319,7 +1319,7 @@ impl From<Vec<u64>> for BitVec {
 impl Extend<BitVec> for BitVec {
     fn extend<T: IntoIterator<Item = BitVec>>(&mut self, iter: T) {
         for v in iter {
-            self.extend_bitvec(&v)
+            self.extend_bitvec(&v);
         }
     }
 }
@@ -1327,7 +1327,7 @@ impl Extend<BitVec> for BitVec {
 impl<'t> Extend<&'t BitVec> for BitVec {
     fn extend<T: IntoIterator<Item = &'t BitVec>>(&mut self, iter: T) {
         for v in iter {
-            self.extend_bitvec(v)
+            self.extend_bitvec(v);
         }
     }
 }

--- a/src/bit_vec/mod.rs
+++ b/src/bit_vec/mod.rs
@@ -13,8 +13,13 @@ pub mod sparse;
 
 pub mod mask;
 
+/// The type we index bits with. Since we can have more bits than valid addresses on 32-bit platforms,
+/// we use [u64] for now. The index tye is exposed in functions that take bit indices, so changing
+/// it is considered a breaking change.
+pub(crate) type BitIndex = u64;
+
 /// Size of a word in bitvectors. All vectors operate on 64-bit words.
-const WORD_SIZE: usize = 64;
+const WORD_SIZE: BitIndex = 64;
 
 /// Type alias for masked bitvectors that implement a simple bitwise binary operation.
 /// The first lifetime is for the bit vector that is being masked, the second lifetime is for the
@@ -60,7 +65,7 @@ pub type BitMask<'s, 'b> = MaskedBitVec<'s, 'b, fn(u64, u64) -> u64>;
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct BitVec {
     data: Vec<u64>,
-    len: usize,
+    len: BitIndex,
 }
 
 impl BitVec {

--- a/src/bit_vec/sparse.rs
+++ b/src/bit_vec/sparse.rs
@@ -2,7 +2,7 @@
 //! The vector requires `O(n log u/n) + 2n + o(n)` bits of space, where `n` is the number of bits in the vector
 //! and `u` is the number of 1-bits.
 //! The vector is constructed from a sorted list of indices of 1-bits, or from an existing
-//! [`BitVec`](crate::BitVec).
+//! [`BitVec`].
 
 use crate::{BitVec, EliasFanoVec};
 
@@ -170,6 +170,8 @@ impl SparseRSVec {
     /// # Panics
     /// If `i` is out of bounds the function might panic or produce incorrect results.
     /// Use [`get`] for a checked version.
+    ///
+    /// [`get`]: Self::get
     #[must_use]
     pub fn get_unchecked(&self, i: u64) -> u64 {
         self.is_set_unchecked(i).into()

--- a/src/bit_vec/sparse.rs
+++ b/src/bit_vec/sparse.rs
@@ -80,7 +80,7 @@ impl SparseRSVec {
     /// - `input`: The input `BitVec` to compress.
     #[must_use]
     pub fn from_bitvec(input: &BitVec) -> Self {
-        let len = input.len() as u64;
+        let len = input.len();
         Self::new(
             input
                 .iter()
@@ -127,7 +127,7 @@ impl SparseRSVec {
     /// [`get`]: #method.get
     #[must_use]
     pub fn from_bitvec_inverted(input: &BitVec) -> Self {
-        let len = input.len() as u64;
+        let len = input.len();
         Self::new(
             input
                 .iter()

--- a/src/bit_vec/sparse.rs
+++ b/src/bit_vec/sparse.rs
@@ -4,6 +4,7 @@
 //! The vector is constructed from a sorted list of indices of 1-bits, or from an existing
 //! [`BitVec`](crate::BitVec).
 
+use crate::bit_vec::BitIndex;
 use crate::{BitVec, EliasFanoVec};
 
 /// A succinct representation of a sparse vector with rank and select support.
@@ -46,7 +47,7 @@ use crate::{BitVec, EliasFanoVec};
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SparseRSVec {
     vec: EliasFanoVec,
-    len: u64,
+    len: BitIndex,
 }
 
 impl SparseRSVec {
@@ -253,6 +254,7 @@ impl<'a> From<&'a BitVec> for SparseRSVec {
 #[cfg(test)]
 mod tests {
     use super::SparseRSVec;
+    use crate::bit_vec::BitIndex;
     use crate::BitVec;
     use rand::prelude::StdRng;
     use rand::{Rng, SeedableRng};
@@ -383,7 +385,7 @@ mod tests {
 
     #[test]
     fn test_fuzzy() {
-        const L: usize = 100_000;
+        const L: BitIndex = 100_000;
         let mut bv = BitVec::from_zeros(L);
         let mut rng = StdRng::from_seed([0; 32]);
 

--- a/src/bit_vec/sparse.rs
+++ b/src/bit_vec/sparse.rs
@@ -188,7 +188,7 @@ impl SparseRSVec {
     ///
     /// If the rank is larger than the number of sparse bits in the vector, the vector length is returned.
     #[must_use]
-    pub fn select1(&self, i: usize) -> u64 {
+    pub fn select1(&self, i: u64) -> u64 {
         self.vec.get(i).unwrap_or(self.len)
     }
 
@@ -399,7 +399,7 @@ mod tests {
             assert_eq!(ones, sparse.rank1(i));
             assert_eq!(i - ones, sparse.rank0(i));
             if bv.get(i) == Some(1) {
-                assert_eq!(i, sparse.select1(ones as usize).try_into().unwrap());
+                assert_eq!(i, sparse.select1(ones).try_into().unwrap());
                 ones += 1;
             }
         }

--- a/src/bit_vec/sparse.rs
+++ b/src/bit_vec/sparse.rs
@@ -4,7 +4,6 @@
 //! The vector is constructed from a sorted list of indices of 1-bits, or from an existing
 //! [`BitVec`](crate::BitVec).
 
-use crate::bit_vec::BitIndex;
 use crate::{BitVec, EliasFanoVec};
 
 /// A succinct representation of a sparse vector with rank and select support.
@@ -47,7 +46,7 @@ use crate::{BitVec, EliasFanoVec};
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SparseRSVec {
     vec: EliasFanoVec,
-    len: BitIndex,
+    len: u64,
 }
 
 impl SparseRSVec {
@@ -254,7 +253,6 @@ impl<'a> From<&'a BitVec> for SparseRSVec {
 #[cfg(test)]
 mod tests {
     use super::SparseRSVec;
-    use crate::bit_vec::BitIndex;
     use crate::BitVec;
     use rand::prelude::StdRng;
     use rand::{Rng, SeedableRng};
@@ -385,7 +383,7 @@ mod tests {
 
     #[test]
     fn test_fuzzy() {
-        const L: BitIndex = 100_000;
+        const L: u64 = 100_000;
         let mut bv = BitVec::from_zeros(L);
         let mut rng = StdRng::from_seed([0; 32]);
 
@@ -397,9 +395,9 @@ mod tests {
 
         let mut ones = 0;
         for i in 0..L {
-            assert_eq!(bv.get(i), sparse.get(i as u64));
-            assert_eq!(ones, sparse.rank1(i as u64));
-            assert_eq!(i as u64 - ones, sparse.rank0(i as u64));
+            assert_eq!(bv.get(i), sparse.get(i));
+            assert_eq!(ones, sparse.rank1(i));
+            assert_eq!(i - ones, sparse.rank0(i));
             if bv.get(i) == Some(1) {
                 assert_eq!(i, sparse.select1(ones as usize).try_into().unwrap());
                 ones += 1;

--- a/src/bit_vec/tests.rs
+++ b/src/bit_vec/tests.rs
@@ -619,8 +619,8 @@ fn test_unpack() {
     let bv = BitVec::pack_sequence_u64(&sequence, 10);
 
     for (i, &val) in sequence.iter().enumerate() {
-        assert_eq!(bv.unpack_element(i, 10), Some(val));
-        assert_eq!(bv.unpack_element_unchecked(i, 10), val);
+        assert_eq!(bv.unpack_element(i as u64, 10), Some(val));
+        assert_eq!(bv.unpack_element_unchecked(i as u64, 10), val);
     }
 
     assert_eq!(bv.unpack_element(8, 10), None);

--- a/src/elias_fano/mod.rs
+++ b/src/elias_fano/mod.rs
@@ -298,10 +298,10 @@ impl EliasFanoVec {
                     if cursor.unsigned_abs() == BIN_SEARCH_THRESHOLD {
                         let block_end = if UPWARD {
                             self.upper_vec.select0((query_upper as i64 + 1) as u64)
-                                - query_upper as u64
+                                - query_upper
                                 - 2
                         } else {
-                            self.upper_vec.select0((query_upper as i64) as u64) - query_upper as u64
+                            self.upper_vec.select0((query_upper as i64) as u64) - query_upper
                         };
 
                         let mut upper_bound;
@@ -387,7 +387,7 @@ impl EliasFanoVec {
                     // the loop ended because the element at cursor has a larger upper index,
                     // so we return the previous element count
                     // (element at curser - 1, +1 because count is not 0 based)
-                    start_index_lower as u64 + cursor as u64
+                    start_index_lower + cursor as u64
                 } else {
                     (query_masked_upper | lower_candidate) + self.universe_zero
                 };
@@ -398,7 +398,7 @@ impl EliasFanoVec {
             // all elements in the 1-block are larger than the query,
             // so we return the last element count
             // (start_index_lower - 1, +1 because count is not 0 based)
-            start_index_lower as u64
+            start_index_lower
         } else {
             self.get_unchecked((start_index_lower as i64 - direction) as u64)
         }
@@ -582,7 +582,7 @@ impl EliasFanoVec {
         let upper = value >> self.lower_len;
         let lower = value & ((1 << self.lower_len) - 1);
         let query_begin = self.upper_vec.select0(upper);
-        let lower_index = query_begin as u64 - upper;
+        let lower_index = query_begin - upper;
 
         self.search_element_in_block::<true, true>(
             query_begin,

--- a/src/elias_fano/mod.rs
+++ b/src/elias_fano/mod.rs
@@ -164,6 +164,8 @@ impl EliasFanoVec {
     ///
     /// Note, that select in bit-vectors returns an index, while select in Elias-Fano returns the
     /// element at the given rank.
+    ///
+    /// [`get`]: Self::get
     #[must_use]
     pub fn select(&self, rank: usize) -> Option<u64> {
         self.get(rank)

--- a/src/elias_fano/mod.rs
+++ b/src/elias_fano/mod.rs
@@ -17,7 +17,7 @@ use std::cmp::max;
 /// friendly. But for large clusters this takes too long, so we switch to binary search.
 /// We use 4 because benchmarks suggested that this was the best trade-off between speed for average
 /// case and for worst case.
-const BIN_SEARCH_THRESHOLD: usize = 4;
+const BIN_SEARCH_THRESHOLD: u64 = 4;
 
 /// An Elias-Fano encoded vector of u64 values. The vector is immutable, which is exploited by
 /// limiting the word length of elements to the minimum required to represent all elements.
@@ -61,8 +61,8 @@ pub struct EliasFanoVec {
     lower_vec: BitVec,
     universe_zero: u64,
     universe_max: u64,
-    lower_len: usize,
-    len: usize,
+    lower_len: u64,
+    len: u64,
 }
 
 impl EliasFanoVec {
@@ -102,23 +102,23 @@ impl EliasFanoVec {
         let universe_zero = data[0];
         let universe_bound = data[data.len() - 1] - universe_zero;
 
-        let log_n = ((data.len() + 2) as f64).log2().ceil() as usize;
-        let bits_per_number = (max(universe_bound, 2) as f64).log2().ceil() as usize;
-        let bits_for_upper_values = (max(data.len(), 2) as f64).log2().ceil() as usize;
+        let log_n = ((data.len() + 2) as f64).log2().ceil() as u64;
+        let bits_per_number = (max(universe_bound, 2) as f64).log2().ceil() as u64;
+        let bits_for_upper_values = (max(data.len(), 2) as f64).log2().ceil() as u64;
         let lower_width = max(bits_per_number, log_n) - bits_for_upper_values;
         assert!(lower_width < 64);
 
         let mut upper_vec =
-            BitVec::from_zeros(2 + data.len() + (universe_bound >> lower_width) as usize);
-        let mut lower_vec = BitVec::with_capacity(data.len() * lower_width);
+            BitVec::from_zeros(2 + data.len() as u64 + (universe_bound >> lower_width));
+        let mut lower_vec = BitVec::with_capacity(data.len() as u64 * lower_width);
 
         for (i, &word) in data.iter().enumerate() {
             let word = word - universe_zero;
 
-            let upper = (word >> lower_width) as usize;
+            let upper = word >> lower_width;
             let lower = word & ((1 << lower_width) - 1);
 
-            upper_vec.flip_bit_unchecked(upper + i + 1);
+            upper_vec.flip_bit_unchecked(upper + i as u64 + 1);
             lower_vec.append_bits_unchecked(lower, lower_width);
         }
 
@@ -128,13 +128,13 @@ impl EliasFanoVec {
             universe_zero,
             universe_max: data[data.len() - 1],
             lower_len: lower_width,
-            len: data.len(),
+            len: data.len() as u64,
         }
     }
 
     /// Returns the number of elements in the vector.
     #[must_use]
-    pub fn len(&self) -> usize {
+    pub fn len(&self) -> u64 {
         self.len
     }
 
@@ -147,7 +147,7 @@ impl EliasFanoVec {
     /// Returns the element at the given index, or `None` if the index exceeds the length of the
     /// vector.
     #[must_use]
-    pub fn get(&self, index: usize) -> Option<u64> {
+    pub fn get(&self, index: u64) -> Option<u64> {
         if index >= self.len() {
             return None;
         }
@@ -165,7 +165,7 @@ impl EliasFanoVec {
     /// Note, that select in bit-vectors returns an index, while select in Elias-Fano returns the
     /// element at the given rank.
     #[must_use]
-    pub fn select(&self, rank: usize) -> Option<u64> {
+    pub fn select(&self, rank: u64) -> Option<u64> {
         self.get(rank)
     }
 
@@ -178,12 +178,12 @@ impl EliasFanoVec {
     /// [`get`]: EliasFanoVec::get
     #[must_use]
     #[allow(clippy::cast_possible_truncation)]
-    pub fn get_unchecked(&self, index: usize) -> u64 {
+    pub fn get_unchecked(&self, index: u64) -> u64 {
         let upper = self.upper_vec.select1(index) - index - 1;
         let lower = self
             .lower_vec
             .get_bits_unchecked(index * self.lower_len, self.lower_len);
-        ((upper << self.lower_len) as u64 | lower) + self.universe_zero
+        ((upper << self.lower_len) | lower) + self.universe_zero
     }
 
     /// Returns the largest element that is smaller than or equal to the query.
@@ -214,15 +214,15 @@ impl EliasFanoVec {
     #[allow(clippy::cast_possible_truncation)] // we will fix this in a breaking update
     fn search_element_in_block<const INDEX: bool, const UPWARD: bool>(
         &self,
-        start_index_upper: usize,
-        start_index_lower: usize,
+        start_index_upper: u64,
+        start_index_lower: u64,
         query: u64,
         query_upper: u64,
         query_lower: u64,
         query_masked_upper: u64,
     ) -> u64 {
         // the direction in which we search for the element, dependent on the UPWARD flag
-        let direction: isize = if UPWARD { 1 } else { -1 };
+        let direction: i64 = if UPWARD { 1 } else { -1 };
 
         // the function to check if the current candidate no longer fulfills the query
         // criterion
@@ -246,12 +246,12 @@ impl EliasFanoVec {
         // last element.
         if self
             .upper_vec
-            .get_unchecked((start_index_upper as isize + direction) as usize)
+            .get_unchecked((start_index_upper as i64 + direction) as u64)
             > 0
         {
             // get the first value from the lower vector that corresponds to the query prefix
             let mut lower_candidate = self.lower_vec.get_bits_unchecked(
-                (start_index_lower as isize) as usize * self.lower_len,
+                (start_index_lower as i64) as u64 * self.lower_len,
                 self.lower_len,
             );
 
@@ -263,11 +263,11 @@ impl EliasFanoVec {
                 let mut cursor = direction;
                 while self
                     .upper_vec
-                    .get_unchecked((start_index_upper as isize + cursor + direction) as usize)
+                    .get_unchecked((start_index_upper as i64 + cursor + direction) as u64)
                     > 0
                 {
                     let next_candidate = self.lower_vec.get_bits_unchecked(
-                        (start_index_lower as isize + cursor) as usize * self.lower_len,
+                        (start_index_lower as i64 + cursor) as u64 * self.lower_len,
                         self.lower_len,
                     );
 
@@ -277,13 +277,13 @@ impl EliasFanoVec {
                         || (!UPWARD && next_candidate < query_lower)
                     {
                         return if INDEX {
-                            start_index_lower as u64 + cursor as u64
+                            start_index_lower + cursor as u64
                         } else {
                             (query_masked_upper | lower_candidate) + self.universe_zero
                         };
                     } else if next_candidate == query_lower {
                         return if INDEX {
-                            start_index_lower as u64 + cursor as u64
+                            start_index_lower + cursor as u64
                         } else {
                             (query_masked_upper | next_candidate) + self.universe_zero
                         };
@@ -297,23 +297,20 @@ impl EliasFanoVec {
                     #[allow(clippy::comparison_chain)] // readability
                     if cursor.unsigned_abs() == BIN_SEARCH_THRESHOLD {
                         let block_end = if UPWARD {
-                            self.upper_vec.select0((query_upper as isize + 1) as usize)
-                                - query_upper as usize
+                            self.upper_vec.select0((query_upper as i64 + 1) as u64)
+                                - query_upper as u64
                                 - 2
                         } else {
-                            self.upper_vec.select0((query_upper as isize) as usize)
-                                - query_upper as usize
+                            self.upper_vec.select0((query_upper as i64) as u64) - query_upper as u64
                         };
 
                         let mut upper_bound;
                         let mut lower_bound;
                         if UPWARD {
                             upper_bound = block_end;
-                            lower_bound =
-                                (start_index_lower as isize + cursor - direction) as usize;
+                            lower_bound = (start_index_lower as i64 + cursor - direction) as u64;
                         } else {
-                            upper_bound =
-                                (start_index_lower as isize + cursor - direction) as usize;
+                            upper_bound = (start_index_lower as i64 + cursor - direction) as u64;
                             lower_bound = block_end;
                         }
 
@@ -332,10 +329,10 @@ impl EliasFanoVec {
                                 upper_bound = middle;
                             } else if middle_candidate == query_lower {
                                 return if INDEX {
-                                    cursor = middle as isize;
+                                    cursor = middle as i64;
                                     // while the element at cursor - 1 is equal, reduce cursor
                                     while self.lower_vec.get_bits_unchecked(
-                                        (cursor - direction) as usize * self.lower_len,
+                                        (cursor - direction) as u64 * self.lower_len,
                                         self.lower_len,
                                     ) == query_lower
                                     {
@@ -362,7 +359,7 @@ impl EliasFanoVec {
                             || (!UPWARD && final_bound > block_end)
                         {
                             let check_candidate = self.lower_vec.get_bits_unchecked(
-                                (final_bound as isize + direction) as usize * self.lower_len,
+                                (final_bound as i64 + direction) as u64 * self.lower_len,
                                 self.lower_len,
                             );
 
@@ -371,7 +368,7 @@ impl EliasFanoVec {
                                     // if the element at lower_bound + 1 is smaller than the query, we include it
                                     // in the count, so we return lower_bound + 1 + 1, as all elements in the
                                     // 1-block are smaller than the query
-                                    (final_bound as isize + direction + 1) as u64
+                                    (final_bound as i64 + direction + 1) as u64
                                 } else {
                                     (query_masked_upper | check_candidate) + self.universe_zero
                                 };
@@ -380,7 +377,7 @@ impl EliasFanoVec {
 
                         // update the cursor because we use it for the final index calculation
                         if INDEX {
-                            cursor = final_bound as isize + direction;
+                            cursor = final_bound as i64 + direction;
                         }
                         break;
                     }
@@ -403,7 +400,7 @@ impl EliasFanoVec {
             // (start_index_lower - 1, +1 because count is not 0 based)
             start_index_lower as u64
         } else {
-            self.get_unchecked((start_index_lower as isize - direction) as usize)
+            self.get_unchecked((start_index_lower as i64 - direction) as u64)
         }
     }
 
@@ -427,7 +424,7 @@ impl EliasFanoVec {
         let n = n - self.universe_zero;
 
         // split the query into the upper and lower part
-        let upper_query = (n >> self.lower_len) as usize;
+        let upper_query = n >> self.lower_len;
         let lower_query = n & ((1 << self.lower_len) - 1);
 
         // calculate the lower bound within the lower vector where our predecessor can be found. Since
@@ -439,13 +436,13 @@ impl EliasFanoVec {
         // calculate the upper part of the result. This only works if the next value in the upper
         // vector is set, otherwise the there is no value in the entire vector with this bit-prefix,
         // and we need to search the largest prefix smaller than the query.
-        let result_upper = (upper_query << self.lower_len) as u64;
+        let result_upper = upper_query << self.lower_len;
 
         self.search_element_in_block::<false, true>(
             lower_bound_upper_index,
             lower_bound_lower_index,
             n,
-            upper_query as u64,
+            upper_query,
             lower_query,
             result_upper,
         )
@@ -488,7 +485,7 @@ impl EliasFanoVec {
         let n = n - self.universe_zero;
 
         // split the query into the upper and lower part
-        let upper_query = (n >> self.lower_len) as usize;
+        let upper_query = n >> self.lower_len;
         let lower_query = n & ((1 << self.lower_len) - 1);
 
         // calculate the upper bound within the lower vector where our successor can be found. Since
@@ -500,13 +497,13 @@ impl EliasFanoVec {
         // calculate the upper part of the result. This only works if the next value in the upper
         // vector is set, otherwise the there is no value in the entire vector with this bit-prefix,
         // and we need to search the largest prefix smaller than the query.
-        let result_upper = (upper_query << self.lower_len) as u64;
+        let result_upper = upper_query << self.lower_len;
 
         self.search_element_in_block::<false, false>(
             upper_bound_upper_index,
             upper_bound_lower_index,
             n,
-            upper_query as u64,
+            upper_query,
             lower_query,
             result_upper,
         )
@@ -531,7 +528,7 @@ impl EliasFanoVec {
     /// assert_eq!(elias_fano_vec.delta(3), Some(80));
     /// ```
     #[must_use]
-    pub fn delta(&self, index: usize) -> Option<u64> {
+    pub fn delta(&self, index: u64) -> Option<u64> {
         if index >= self.len() {
             return None;
         }
@@ -549,7 +546,7 @@ impl EliasFanoVec {
             )
         } else {
             let query_upper_part = (upper_index - index - 1) << self.lower_len;
-            let query_number = query_upper_part as u64
+            let query_number = query_upper_part
                 | self
                     .lower_vec
                     .get_bits_unchecked(index * self.lower_len, self.lower_len);
@@ -561,7 +558,7 @@ impl EliasFanoVec {
                 let lower_element_upper_index = self.upper_vec.select1(index - 1);
                 let lower_element_upper = lower_element_upper_index - (index - 1) - 1;
 
-                let lower_elem = ((lower_element_upper as u64) << self.lower_len as u64)
+                let lower_elem = (lower_element_upper << self.lower_len)
                     | self
                         .lower_vec
                         .get_bits_unchecked((index - 1) * self.lower_len, self.lower_len);
@@ -572,10 +569,9 @@ impl EliasFanoVec {
 
     /// Return how many elements strictly smaller than the query element are present in the vector.
     #[must_use]
-    #[allow(clippy::cast_possible_truncation)] // we will fix this in a breaking update
     pub fn rank(&self, value: u64) -> u64 {
         if value > self.universe_max || self.is_empty() {
-            return self.len() as u64;
+            return self.len();
         }
 
         if value < self.universe_zero {
@@ -585,12 +581,12 @@ impl EliasFanoVec {
         let value = value - self.universe_zero;
         let upper = value >> self.lower_len;
         let lower = value & ((1 << self.lower_len) - 1);
-        let query_begin = self.upper_vec.select0(upper as usize);
+        let query_begin = self.upper_vec.select0(upper);
         let lower_index = query_begin as u64 - upper;
 
         self.search_element_in_block::<true, true>(
             query_begin,
-            lower_index as usize,
+            lower_index,
             value,
             upper,
             lower,

--- a/src/elias_fano/tests.rs
+++ b/src/elias_fano/tests.rs
@@ -62,10 +62,10 @@ fn test_randomized_elias_fano() {
 
     let ef = EliasFanoVec::from_slice(&seq);
 
-    assert_eq!(ef.len(), seq.len());
+    assert_eq!(ef.len(), seq.len() as u64);
 
     for (i, &v) in seq.iter().enumerate() {
-        assert_eq!(ef.get_unchecked(i), v);
+        assert_eq!(ef.get_unchecked(i as u64), v);
     }
 
     for _ in 0..1000 {
@@ -110,7 +110,7 @@ fn test_clustered_ef() {
 
     let ef = EliasFanoVec::from_slice(&seq);
     for (i, &x) in seq.iter().enumerate() {
-        assert_eq!(ef.get_unchecked(i), x, "expected {:b}", x);
+        assert_eq!(ef.get_unchecked(i as u64), x, "expected {:b}", x);
         assert_eq!(ef.predecessor_unchecked(x), x);
         assert_eq!(ef.successor_unchecked(x), x);
     }
@@ -398,10 +398,10 @@ fn test_randomized_elias_fano_successor() {
 
     let ef = EliasFanoVec::from_slice(&seq);
 
-    assert_eq!(ef.len(), seq.len());
+    assert_eq!(ef.len(), seq.len() as u64);
 
     for (i, &v) in seq.iter().enumerate() {
-        assert_eq!(ef.get_unchecked(i), v);
+        assert_eq!(ef.get_unchecked(i as u64), v);
     }
 
     for _ in 0..1000 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@
 #![allow(clippy::module_name_repetitions)]
 #![allow(clippy::assertions_on_constants)] // for asserts warning about incompatible constant values
 #![allow(clippy::inline_always)] // we actually measure performance increases with most of these
+#![allow(clippy::cast_lossless)] // it is often more readable to use `as u64` instead of `u64::from(..)`
 #![cfg_attr(docsrs, feature(doc_cfg), feature(doc_auto_cfg))] // for conditional compilation in docs
 
 //! This crate provides a collection of data structures supported by fast implementations of

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,14 +1,3 @@
-#![cfg_attr(
-    all(
-        feature = "simd",
-        target_arch = "x86_64",
-        target_feature = "avx",
-        target_feature = "avx2",
-        target_feature = "avx512f",
-        target_feature = "avx512bw",
-    ),
-    feature(stdarch_x86_avx512)
-)]
 #![warn(missing_docs)]
 #![allow(clippy::module_name_repetitions)]
 #![allow(clippy::assertions_on_constants)] // for asserts warning about incompatible constant values

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::module_name_repetitions)]
 #![allow(clippy::assertions_on_constants)] // for asserts warning about incompatible constant values
 #![allow(clippy::inline_always)] // we actually measure performance increases with most of these
-#![cfg_attr(docsrs, feature(doc_cfg), feature(doc_auto_cfg))] // for conditional compilation in docs
+#![cfg_attr(docsrs, feature(doc_cfg))] // for conditional compilation in docs
 
 //! This crate provides a collection of data structures supported by fast implementations of
 //! rank and select queries. The data structures are static, meaning that they cannot be modified

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 #![allow(clippy::assertions_on_constants)] // for asserts warning about incompatible constant values
 #![allow(clippy::inline_always)] // we actually measure performance increases with most of these
 #![allow(clippy::cast_lossless)] // it is often more readable to use `as u64` instead of `u64::from(..)`
+#![allow(clippy::needless_for_each)] // readability of one-liners
 #![cfg_attr(docsrs, feature(doc_cfg))] // for conditional compilation in docs
 
 //! This crate provides a collection of data structures supported by fast implementations of

--- a/src/trees/bp/builder.rs
+++ b/src/trees/bp/builder.rs
@@ -6,12 +6,12 @@ use crate::BitVec;
 /// [`TreeBuilder`].
 ///
 /// [`BpTree`]: BpTree
-pub struct BpBuilder<const BLOCK_SIZE: usize = DEFAULT_BLOCK_SIZE> {
+pub struct BpBuilder<const BLOCK_SIZE: u64 = DEFAULT_BLOCK_SIZE> {
     excess: i64,
     bit_vec: BitVec,
 }
 
-impl<const BLOCK_SIZE: usize> BpBuilder<BLOCK_SIZE> {
+impl<const BLOCK_SIZE: u64> BpBuilder<BLOCK_SIZE> {
     /// Create new empty `DfsTreeBuilder`
     #[must_use]
     pub fn new() -> Self {
@@ -31,13 +31,13 @@ impl<const BLOCK_SIZE: usize> BpBuilder<BLOCK_SIZE> {
     }
 }
 
-impl<const BLOCK_SIZE: usize> Default for BpBuilder<BLOCK_SIZE> {
+impl<const BLOCK_SIZE: u64> Default for BpBuilder<BLOCK_SIZE> {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<const BLOCK_SIZE: usize> TreeBuilder for BpBuilder<BLOCK_SIZE> {
+impl<const BLOCK_SIZE: u64> TreeBuilder for BpBuilder<BLOCK_SIZE> {
     type Tree = BpTree<BLOCK_SIZE>;
 
     fn enter_node(&mut self) {

--- a/src/trees/bp/builder.rs
+++ b/src/trees/bp/builder.rs
@@ -5,7 +5,8 @@ use crate::BitVec;
 /// A builder for [`BpTrees`] using depth-first traversal of the tree. See the documentation of
 /// [`TreeBuilder`].
 ///
-/// [`BpTree`]: BpTree
+/// [`BpTrees`]: BpTree
+/// [`TreeBuilder`]: TreeBuilder
 pub struct BpBuilder<const BLOCK_SIZE: usize = DEFAULT_BLOCK_SIZE> {
     excess: i64,
     bit_vec: BitVec,

--- a/src/trees/bp/builder.rs
+++ b/src/trees/bp/builder.rs
@@ -26,7 +26,7 @@ impl<const BLOCK_SIZE: usize> BpBuilder<BLOCK_SIZE> {
     pub fn with_capacity(capacity: u64) -> Self {
         Self {
             excess: 0,
-            bit_vec: BitVec::with_capacity((capacity * 2) as usize),
+            bit_vec: BitVec::with_capacity(capacity * 2),
         }
     }
 }

--- a/src/trees/bp/lookup.rs
+++ b/src/trees/bp/lookup.rs
@@ -1,3 +1,6 @@
+#![allow(clippy::cast_sign_loss)] // sign loss cannot happen on correctly formed BP trees
+#![allow(clippy::cast_possible_wrap)] // ditto
+
 //! This module provides the lookup table and lookup functionality to answer excess queries
 //! for 8-bit and 16-bit blocks in the tree vector.
 //! Note that the 8-bit version is unused, since this whole module gets replaced with
@@ -52,6 +55,7 @@ const PAREN_BLOCK_LOOKUP: [EncodedTableType; 1 << LOOKUP_BLOCK_SIZE] = calculate
 
 /// Offset to add to encoded excess values, so negative numbers are stored as positive integers, reducing
 /// encoding complexity
+#[allow(clippy::cast_possible_truncation)] // false positive
 const ENCODING_OFFSET: i32 = LOOKUP_BLOCK_SIZE as i32;
 
 /// Bitmask for one of the lookup values.
@@ -66,6 +70,7 @@ const MINIMUM_EXCESS_POSITION: usize = 6;
 #[cfg(not(feature = "bp_u16_lookup"))]
 const MINIMUM_EXCESS_POSITION: usize = 5;
 
+#[allow(clippy::cast_possible_truncation)] // all values are in range
 const fn calculate_lookup_table() -> [EncodedTableType; 1 << LOOKUP_BLOCK_SIZE] {
     // initial sentinel values during excess computation
     const MORE_THAN_MAX: SignedLookupBlockType = (LOOKUP_BLOCK_SIZE + 1) as SignedLookupBlockType;
@@ -114,12 +119,14 @@ const fn get_maximum_excess(value: EncodedTableType) -> i64 {
 }
 
 /// Branchless const minimum computation for values that cannot overflow
+#[allow(clippy::cast_possible_truncation)] // all values are in range
 const fn min(a: SignedLookupBlockType, b: SignedLookupBlockType) -> SignedLookupBlockType {
     b + ((a - b)
         & -(((a - b) as LookupBlockType >> (LOOKUP_BLOCK_SIZE - 1)) as SignedLookupBlockType))
 }
 
 /// Branchless const maximum computation for values that cannot overflow
+#[allow(clippy::cast_possible_truncation)] // all values are in range
 const fn max(a: SignedLookupBlockType, b: SignedLookupBlockType) -> SignedLookupBlockType {
     a - ((a - b)
         & -(((a - b) as LookupBlockType >> (LOOKUP_BLOCK_SIZE - 1)) as SignedLookupBlockType))

--- a/src/trees/bp/mod.rs
+++ b/src/trees/bp/mod.rs
@@ -336,7 +336,7 @@ impl<const BLOCK_SIZE: u64> BpTree<BLOCK_SIZE> {
                     .unwrap(),
                 relative_excess,
             ) {
-                return Ok(block_boundary + i as u64 + idx as u64);
+                return Ok(block_boundary + i as u64 + idx);
             }
         }
 

--- a/src/trees/bp/mod.rs
+++ b/src/trees/bp/mod.rs
@@ -168,6 +168,7 @@ impl<const BLOCK_SIZE: u64> BpTree<BLOCK_SIZE> {
             return None;
         }
 
+        #[allow(clippy::cast_possible_truncation)] // safe due to the division
         let block_index = ((index + 1) / BLOCK_SIZE) as usize;
         self.fwd_search_block(index, block_index, &mut relative_excess)
             .map_or_else(
@@ -224,6 +225,7 @@ impl<const BLOCK_SIZE: u64> BpTree<BLOCK_SIZE> {
             (block_boundary / LOOKUP_BLOCK_SIZE) * LOOKUP_BLOCK_SIZE,
         );
 
+        // TODO truncation
         for i in (lookup_boundary..upper_lookup_boundary).step_by(LOOKUP_BLOCK_SIZE as usize) {
             if let Ok(idx) = process_block_fwd(
                 self.vec
@@ -271,6 +273,7 @@ impl<const BLOCK_SIZE: u64> BpTree<BLOCK_SIZE> {
 
         // calculate the block we start searching in. It starts at index - 1, so we don't accidentally
         // search the mM tree and immediately find `index` as the position
+        #[allow(clippy::cast_possible_truncation)] // safe due to the division
         let block_index = ((index - 1) / BLOCK_SIZE) as usize;
 
         // check the current block
@@ -325,6 +328,7 @@ impl<const BLOCK_SIZE: u64> BpTree<BLOCK_SIZE> {
 
         // lookup_boundary - block_boundary is smaller than a block, so casting to usize cannot
         // truncate
+        // TODO truncation
         for i in (0..(lookup_boundary - block_boundary) as usize)
             .step_by(LOOKUP_BLOCK_SIZE as usize)
             .rev()
@@ -459,6 +463,7 @@ impl<const BLOCK_SIZE: u64> BpTree<BLOCK_SIZE> {
         let subtree_size = self.vec.rank1(close) - index;
 
         // we accept if this truncates, since we cannot change the definition of iterator traits
+        // TODO truncation
         self.vec
             .iter1()
             .skip(index as usize)
@@ -492,6 +497,7 @@ impl<const BLOCK_SIZE: u64> BpTree<BLOCK_SIZE> {
         let subtree_size = self.vec.rank0(close) + 1 - index;
 
         // we accept if this truncates, since we cannot change the definition of iterator traits
+        // TODO truncation
         self.vec
             .iter0()
             .skip(index as usize)

--- a/src/trees/bp/mod.rs
+++ b/src/trees/bp/mod.rs
@@ -11,7 +11,7 @@ use std::cmp::{max, min};
 use std::iter::FusedIterator;
 
 /// The default block size for the tree, used in several const generics
-const DEFAULT_BLOCK_SIZE: usize = 512;
+const DEFAULT_BLOCK_SIZE: u64 = 512;
 
 const OPEN_PAREN: u64 = 1;
 const CLOSE_PAREN: u64 = 0;
@@ -139,12 +139,12 @@ use lookup_query::{process_block_bwd, process_block_fwd, LOOKUP_BLOCK_SIZE};
 /// [`BitVec`]: BitVec
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct BpTree<const BLOCK_SIZE: usize = DEFAULT_BLOCK_SIZE> {
+pub struct BpTree<const BLOCK_SIZE: u64 = DEFAULT_BLOCK_SIZE> {
     vec: RsVec,
     min_max_tree: MinMaxTree,
 }
 
-impl<const BLOCK_SIZE: usize> BpTree<BLOCK_SIZE> {
+impl<const BLOCK_SIZE: u64> BpTree<BLOCK_SIZE> {
     /// Construct a new `BpTree` from a given bit vector.
     #[must_use]
     pub fn from_bit_vector(bv: BitVec) -> Self {
@@ -161,14 +161,14 @@ impl<const BLOCK_SIZE: usize> BpTree<BLOCK_SIZE> {
     /// # Arguments
     /// - `index`: The starting index.
     /// - `relative_excess`: The desired relative excess value.
-    pub fn fwd_search(&self, index: usize, mut relative_excess: i64) -> Option<usize> {
+    pub fn fwd_search(&self, index: u64, mut relative_excess: i64) -> Option<u64> {
         // check for greater than or equal length minus one, because the last element
         // won't ever have a result from fwd_search
         if index >= (self.vec.len() - 1) {
             return None;
         }
 
-        let block_index = (index + 1) / BLOCK_SIZE;
+        let block_index = ((index + 1) / BLOCK_SIZE) as usize;
         self.fwd_search_block(index, block_index, &mut relative_excess)
             .map_or_else(
                 |()| {
@@ -177,8 +177,12 @@ impl<const BLOCK_SIZE: usize> BpTree<BLOCK_SIZE> {
 
                     // check the result block for the exact position
                     block.and_then(|(block, mut relative_excess)| {
-                        self.fwd_search_block(block * BLOCK_SIZE - 1, block, &mut relative_excess)
-                            .ok()
+                        self.fwd_search_block(
+                            block as u64 * BLOCK_SIZE - 1,
+                            block,
+                            &mut relative_excess,
+                        )
+                        .ok()
                     })
                 },
                 Some,
@@ -194,15 +198,15 @@ impl<const BLOCK_SIZE: usize> BpTree<BLOCK_SIZE> {
     #[inline(always)]
     fn fwd_search_block(
         &self,
-        start_index: usize,
+        start_index: u64,
         block_index: usize,
         relative_excess: &mut i64,
-    ) -> Result<usize, ()> {
-        let block_boundary = min((block_index + 1) * BLOCK_SIZE, self.vec.len());
+    ) -> Result<u64, ()> {
+        let block_boundary = min((block_index as u64 + 1) * BLOCK_SIZE, self.vec.len());
 
         // the boundary at which we can start with table lookups
         let lookup_boundary = min(
-            (start_index + 1).div_ceil(LOOKUP_BLOCK_SIZE as usize) * LOOKUP_BLOCK_SIZE as usize,
+            (start_index + 1).div_ceil(LOOKUP_BLOCK_SIZE) * LOOKUP_BLOCK_SIZE,
             block_boundary,
         );
         for i in start_index + 1..lookup_boundary {
@@ -217,18 +221,18 @@ impl<const BLOCK_SIZE: usize> BpTree<BLOCK_SIZE> {
         // the boundary up to which we can use table lookups
         let upper_lookup_boundary = max(
             lookup_boundary,
-            (block_boundary / LOOKUP_BLOCK_SIZE as usize) * LOOKUP_BLOCK_SIZE as usize,
+            (block_boundary / LOOKUP_BLOCK_SIZE) * LOOKUP_BLOCK_SIZE,
         );
 
         for i in (lookup_boundary..upper_lookup_boundary).step_by(LOOKUP_BLOCK_SIZE as usize) {
             if let Ok(idx) = process_block_fwd(
                 self.vec
-                    .get_bits_unchecked(i, LOOKUP_BLOCK_SIZE as usize)
+                    .get_bits_unchecked(i, LOOKUP_BLOCK_SIZE)
                     .try_into()
                     .unwrap(),
                 relative_excess,
             ) {
-                return Ok(i + idx as usize);
+                return Ok(i + idx);
             }
         }
 
@@ -254,7 +258,7 @@ impl<const BLOCK_SIZE: usize> BpTree<BLOCK_SIZE> {
     /// # Arguments
     /// - `index`: The starting index.
     /// - `relative_excess`: The desired relative excess value.
-    pub fn bwd_search(&self, index: usize, mut relative_excess: i64) -> Option<usize> {
+    pub fn bwd_search(&self, index: u64, mut relative_excess: i64) -> Option<u64> {
         if index >= self.vec.len() {
             return None;
         }
@@ -267,7 +271,7 @@ impl<const BLOCK_SIZE: usize> BpTree<BLOCK_SIZE> {
 
         // calculate the block we start searching in. It starts at index - 1, so we don't accidentally
         // search the mM tree and immediately find `index` as the position
-        let block_index = (index - 1) / BLOCK_SIZE;
+        let block_index = ((index - 1) / BLOCK_SIZE) as usize;
 
         // check the current block
         self.bwd_search_block(index, block_index, &mut relative_excess)
@@ -278,8 +282,12 @@ impl<const BLOCK_SIZE: usize> BpTree<BLOCK_SIZE> {
 
                     // check the result block for the exact position
                     block.and_then(|(block, mut relative_excess)| {
-                        self.bwd_search_block((block + 1) * BLOCK_SIZE, block, &mut relative_excess)
-                            .ok()
+                        self.bwd_search_block(
+                            (block as u64 + 1) * BLOCK_SIZE,
+                            block,
+                            &mut relative_excess,
+                        )
+                        .ok()
                     })
                 },
                 Some,
@@ -295,15 +303,15 @@ impl<const BLOCK_SIZE: usize> BpTree<BLOCK_SIZE> {
     #[inline(always)]
     fn bwd_search_block(
         &self,
-        start_index: usize,
+        start_index: u64,
         block_index: usize,
         relative_excess: &mut i64,
-    ) -> Result<usize, ()> {
-        let block_boundary = min(block_index * BLOCK_SIZE, self.vec.len());
+    ) -> Result<u64, ()> {
+        let block_boundary = min(block_index as u64 * BLOCK_SIZE, self.vec.len());
 
         // the boundary at which we can start with table lookups
         let lookup_boundary = max(
-            ((start_index - 1) / LOOKUP_BLOCK_SIZE as usize) * LOOKUP_BLOCK_SIZE as usize,
+            ((start_index - 1) / LOOKUP_BLOCK_SIZE) * LOOKUP_BLOCK_SIZE,
             block_boundary,
         );
         for i in (lookup_boundary..start_index).rev() {
@@ -321,12 +329,12 @@ impl<const BLOCK_SIZE: usize> BpTree<BLOCK_SIZE> {
         {
             if let Ok(idx) = process_block_bwd(
                 self.vec
-                    .get_bits_unchecked(i, LOOKUP_BLOCK_SIZE as usize)
+                    .get_bits_unchecked(i, LOOKUP_BLOCK_SIZE)
                     .try_into()
                     .unwrap(),
                 relative_excess,
             ) {
-                return Ok(i + idx as usize);
+                return Ok(i + idx as u64);
             }
         }
 
@@ -337,7 +345,7 @@ impl<const BLOCK_SIZE: usize> BpTree<BLOCK_SIZE> {
     /// If the bit at `index` is not an opening parenthesis, the result is meaningless.
     /// If there is no matching closing parenthesis, `None` is returned.
     #[must_use]
-    pub fn close(&self, index: usize) -> Option<usize> {
+    pub fn close(&self, index: u64) -> Option<u64> {
         if index >= self.vec.len() {
             return None;
         }
@@ -349,7 +357,7 @@ impl<const BLOCK_SIZE: usize> BpTree<BLOCK_SIZE> {
     /// If the bit at `index` is not a closing parenthesis, the result is meaningless.
     /// If there is no matching opening parenthesis, `None` is returned.
     #[must_use]
-    pub fn open(&self, index: usize) -> Option<usize> {
+    pub fn open(&self, index: u64) -> Option<u64> {
         if index >= self.vec.len() {
             return None;
         }
@@ -361,7 +369,7 @@ impl<const BLOCK_SIZE: usize> BpTree<BLOCK_SIZE> {
     /// This works regardless of whether the bit at `index` is an opening or closing parenthesis.
     /// If there is no enclosing parenthesis, `None` is returned.
     #[must_use]
-    pub fn enclose(&self, index: usize) -> Option<usize> {
+    pub fn enclose(&self, index: u64) -> Option<u64> {
         if index >= self.vec.len() {
             return None;
         }
@@ -380,7 +388,7 @@ impl<const BLOCK_SIZE: usize> BpTree<BLOCK_SIZE> {
     /// The excess is the number of open parentheses minus the number of closing parentheses.
     /// If `index` is out of bounds, the total excess of the parentheses expression is returned.
     #[must_use]
-    pub fn excess(&self, index: usize) -> i64 {
+    pub fn excess(&self, index: u64) -> i64 {
         debug_assert!(index < self.vec.len(), "Index out of bounds");
         self.vec.rank1(index + 1) as i64 - self.vec.rank0(index + 1) as i64
     }
@@ -426,8 +434,14 @@ impl<const BLOCK_SIZE: usize> BpTree<BLOCK_SIZE> {
     /// Iterate over a subtree rooted at `node` in depth-first (pre-)order.
     /// The iteration starts with the node itself.
     ///
+    /// # Limitations
+    /// When called on an architecture where `usize` is smaller than 64 bits, on a tree with more
+    /// than 2^31 nodes, the iterator may produce an iterator over an unspecified subset of nodes.
+    ///
+    /// # Panics
     /// Calling this method on an invalid node handle, or an unbalanced parenthesis expression,
-    /// will produce an iterator over an unspecified subset of nodes.
+    /// will produce an iterator over an unspecified subset of nodes, or panic either during
+    /// construction or iteration.
     pub fn subtree_iter(
         &self,
         node: <BpTree<BLOCK_SIZE> as Tree>::NodeHandle,
@@ -441,12 +455,21 @@ impl<const BLOCK_SIZE: usize> BpTree<BLOCK_SIZE> {
         let close = self.close(node).unwrap_or(node);
         let subtree_size = self.vec.rank1(close) - index;
 
-        self.vec.iter1().skip(index).take(subtree_size)
+        // we accept if this truncates, since we cannot change the definition of iterator traits
+        self.vec
+            .iter1()
+            .skip(index as usize)
+            .take(subtree_size as usize)
     }
 
     /// Iterate over a subtree rooted at `node` in depth-first (post-)order.
     /// This is slower than the pre-order iteration.
     /// The iteration ends with the node itself.
+    ///
+    /// # Limitations
+    /// When called on an architecture where `usize` is smaller than 64 bits, on a tree with more
+    /// than 2^31 nodes, the iterator may return an unspecified number of nodes starting at an
+    /// unspecified node.
     ///
     /// # Panics
     /// Calling this method on an invalid node handle, or an unbalanced parenthesis expression,
@@ -465,10 +488,11 @@ impl<const BLOCK_SIZE: usize> BpTree<BLOCK_SIZE> {
         let close = self.close(node).unwrap_or(node);
         let subtree_size = self.vec.rank0(close) + 1 - index;
 
+        // we accept if this truncates, since we cannot change the definition of iterator traits
         self.vec
             .iter0()
-            .skip(index)
-            .take(subtree_size)
+            .skip(index as usize)
+            .take(subtree_size as usize)
             .map(|n| self.open(n).unwrap())
     }
 
@@ -544,8 +568,8 @@ impl<const BLOCK_SIZE: usize> BpTree<BLOCK_SIZE> {
     }
 }
 
-impl<const BLOCK_SIZE: usize> Tree for BpTree<BLOCK_SIZE> {
-    type NodeHandle = usize;
+impl<const BLOCK_SIZE: u64> Tree for BpTree<BLOCK_SIZE> {
+    type NodeHandle = u64;
 
     fn root(&self) -> Option<Self::NodeHandle> {
         if self.vec.is_empty() {
@@ -627,7 +651,7 @@ impl<const BLOCK_SIZE: usize> Tree for BpTree<BLOCK_SIZE> {
         })
     }
 
-    fn node_index(&self, node: Self::NodeHandle) -> usize {
+    fn node_index(&self, node: Self::NodeHandle) -> u64 {
         debug_assert!(
             self.vec.get(node) == Some(OPEN_PAREN),
             "Node handle is invalid"
@@ -635,7 +659,7 @@ impl<const BLOCK_SIZE: usize> Tree for BpTree<BLOCK_SIZE> {
         self.vec.rank1(node)
     }
 
-    fn node_handle(&self, index: usize) -> Self::NodeHandle {
+    fn node_handle(&self, index: u64) -> Self::NodeHandle {
         self.vec.select1(index)
     }
 
@@ -656,7 +680,7 @@ impl<const BLOCK_SIZE: usize> Tree for BpTree<BLOCK_SIZE> {
         excess.saturating_sub(1)
     }
 
-    fn size(&self) -> usize {
+    fn size(&self) -> u64 {
         self.vec.rank1(self.vec.len())
     }
 
@@ -665,7 +689,7 @@ impl<const BLOCK_SIZE: usize> Tree for BpTree<BLOCK_SIZE> {
     }
 }
 
-impl<const BLOCK_SIZE: usize> IsAncestor for BpTree<BLOCK_SIZE> {
+impl<const BLOCK_SIZE: u64> IsAncestor for BpTree<BLOCK_SIZE> {
     fn is_ancestor(
         &self,
         ancestor: Self::NodeHandle,
@@ -685,7 +709,7 @@ impl<const BLOCK_SIZE: usize> IsAncestor for BpTree<BLOCK_SIZE> {
     }
 }
 
-impl<const BLOCK_SIZE: usize> LevelTree for BpTree<BLOCK_SIZE> {
+impl<const BLOCK_SIZE: u64> LevelTree for BpTree<BLOCK_SIZE> {
     fn level_ancestor(&self, node: Self::NodeHandle, level: u64) -> Option<Self::NodeHandle> {
         if level == 0 {
             return Some(node);
@@ -722,8 +746,8 @@ impl<const BLOCK_SIZE: usize> LevelTree for BpTree<BLOCK_SIZE> {
     }
 }
 
-impl<const BLOCK_SIZE: usize> SubtreeSize for BpTree<BLOCK_SIZE> {
-    fn subtree_size(&self, node: Self::NodeHandle) -> Option<usize> {
+impl<const BLOCK_SIZE: u64> SubtreeSize for BpTree<BLOCK_SIZE> {
+    fn subtree_size(&self, node: Self::NodeHandle) -> Option<u64> {
         debug_assert!(
             self.vec.get(node) == Some(OPEN_PAREN),
             "Node handle is invalid"
@@ -734,7 +758,7 @@ impl<const BLOCK_SIZE: usize> SubtreeSize for BpTree<BLOCK_SIZE> {
     }
 }
 
-impl<const BLOCK_SIZE: usize> IntoIterator for BpTree<BLOCK_SIZE> {
+impl<const BLOCK_SIZE: u64> IntoIterator for BpTree<BLOCK_SIZE> {
     type Item = <BpTree<BLOCK_SIZE> as Tree>::NodeHandle;
     type IntoIter = SelectIntoIter<false>;
 
@@ -743,19 +767,19 @@ impl<const BLOCK_SIZE: usize> IntoIterator for BpTree<BLOCK_SIZE> {
     }
 }
 
-impl<const BLOCK_SIZE: usize> From<BitVec> for BpTree<BLOCK_SIZE> {
+impl<const BLOCK_SIZE: u64> From<BitVec> for BpTree<BLOCK_SIZE> {
     fn from(bv: BitVec) -> Self {
         Self::from_bit_vector(bv)
     }
 }
 
-impl<const BLOCK_SIZE: usize> From<BpTree<BLOCK_SIZE>> for BitVec {
+impl<const BLOCK_SIZE: u64> From<BpTree<BLOCK_SIZE>> for BitVec {
     fn from(value: BpTree<BLOCK_SIZE>) -> Self {
         value.into_parentheses_vec().into_bit_vec()
     }
 }
 
-impl<const BLOCK_SIZE: usize> From<BpTree<BLOCK_SIZE>> for RsVec {
+impl<const BLOCK_SIZE: u64> From<BpTree<BLOCK_SIZE>> for RsVec {
     fn from(value: BpTree<BLOCK_SIZE>) -> Self {
         value.into_parentheses_vec()
     }
@@ -764,13 +788,13 @@ impl<const BLOCK_SIZE: usize> From<BpTree<BLOCK_SIZE>> for RsVec {
 /// An iterator over the children of a node.
 /// Calls to `next` return the next child node handle in the order they appear in the parenthesis
 /// expression.
-struct ChildrenIter<'a, const BLOCK_SIZE: usize, const FORWARD: bool> {
+struct ChildrenIter<'a, const BLOCK_SIZE: u64, const FORWARD: bool> {
     tree: &'a BpTree<BLOCK_SIZE>,
-    current_sibling: Option<usize>,
+    current_sibling: Option<u64>,
 }
 
-impl<'a, const BLOCK_SIZE: usize, const FORWARD: bool> ChildrenIter<'a, BLOCK_SIZE, FORWARD> {
-    fn new(tree: &'a BpTree<BLOCK_SIZE>, node: usize) -> Self {
+impl<'a, const BLOCK_SIZE: u64, const FORWARD: bool> ChildrenIter<'a, BLOCK_SIZE, FORWARD> {
+    fn new(tree: &'a BpTree<BLOCK_SIZE>, node: u64) -> Self {
         Self {
             tree,
             current_sibling: if FORWARD {
@@ -782,7 +806,7 @@ impl<'a, const BLOCK_SIZE: usize, const FORWARD: bool> ChildrenIter<'a, BLOCK_SI
     }
 }
 
-impl<const BLOCK_SIZE: usize, const FORWARD: bool> Iterator
+impl<const BLOCK_SIZE: u64, const FORWARD: bool> Iterator
     for ChildrenIter<'_, BLOCK_SIZE, FORWARD>
 {
     type Item = usize;
@@ -799,7 +823,7 @@ impl<const BLOCK_SIZE: usize, const FORWARD: bool> Iterator
     }
 }
 
-impl<const BLOCK_SIZE: usize, const FORWARD: bool> FusedIterator
+impl<const BLOCK_SIZE: u64, const FORWARD: bool> FusedIterator
     for ChildrenIter<'_, BLOCK_SIZE, FORWARD>
 {
 }

--- a/src/trees/bp/mod.rs
+++ b/src/trees/bp/mod.rs
@@ -390,6 +390,7 @@ impl<const BLOCK_SIZE: u64> BpTree<BLOCK_SIZE> {
     /// The excess is the number of open parentheses minus the number of closing parentheses.
     /// If `index` is out of bounds, the total excess of the parentheses expression is returned.
     #[must_use]
+    #[allow(clippy::cast_possible_wrap)] // only happens if the tree is unbalanced and has more than 2^62 nodes
     pub fn excess(&self, index: u64) -> i64 {
         debug_assert!(index < self.vec.len(), "Index out of bounds");
         self.vec.rank1(index + 1) as i64 - self.vec.rank0(index + 1) as i64

--- a/src/trees/bp/tests.rs
+++ b/src/trees/bp/tests.rs
@@ -144,14 +144,14 @@ fn test_lookup_extreme_pop() {
     let tree = BpTree::<512>::from_bit_vector(bv);
 
     for excess in 1..64 {
-        assert_eq!(tree.fwd_search(0, excess), Some(excess as usize));
+        assert_eq!(tree.fwd_search(0, excess), Some(excess as u64));
     }
 
     let bv = BitVec::from_bits(&[0; 64]);
     let tree = BpTree::<512>::from_bit_vector(bv);
 
     for excess in 1..64 {
-        assert_eq!(tree.fwd_search(0, -excess), Some(excess as usize));
+        assert_eq!(tree.fwd_search(0, -excess), Some(excess as u64));
     }
 }
 
@@ -159,7 +159,7 @@ fn test_lookup_extreme_pop() {
 fn test_fwd_fuzzy() {
     // we're fuzzing forward search a bit
     const L: u64 = 1000;
-    const L_BITS: u64 = L * size_of::<u64>() * 8;
+    const L_BITS: u64 = L * size_of::<u64>() as u64 * 8;
 
     // we generate a vector using a seeded random generator and check that every query works as expected
     let mut rng = StdRng::from_seed([0; 32]);
@@ -191,7 +191,7 @@ fn test_fwd_fuzzy() {
             let expected = excess_values[(node_handle + 1) as usize..]
                 .iter()
                 .position(|&excess| excess as i64 == absolute_excess)
-                .map(|i| i + node_handle + 1);
+                .map(|i| i as u64 + node_handle + 1);
             let actual = bp.fwd_search(node_handle, relative_excess);
             assert_eq!(
                 expected,
@@ -320,8 +320,8 @@ fn test_bwd_block_traversal() {
 #[test]
 fn test_bwd_fuzzy() {
     // we're fuzzing forward search a bit
-    const L: usize = 1000;
-    const L_BITS: usize = L * size_of::<u64>() * 8;
+    const L: u64 = 1000;
+    const L_BITS: u64 = L * size_of::<u64>() as u64 * 8;
 
     // we generate a vector using a seeded random generator and check that every query works as expected
     let mut rng = StdRng::from_seed([0; 32]);
@@ -332,7 +332,7 @@ fn test_bwd_fuzzy() {
     }
 
     // pre-calculate all absolute excess values
-    let mut excess_values = vec![0i16; L_BITS + 1];
+    let mut excess_values = vec![0i16; (L_BITS + 1) as usize];
     let mut excess = 0;
     for (idx, bit) in bit_vec.iter().enumerate() {
         if bit == 1 {
@@ -354,9 +354,10 @@ fn test_bwd_fuzzy() {
             } else {
                 bp.excess(node_handle - 1) + relative_excess
             };
-            let expected = excess_values[..node_handle]
+            let expected = excess_values[..node_handle as usize]
                 .iter()
-                .rposition(|&excess| excess as i64 == absolute_excess);
+                .rposition(|&excess| excess as i64 == absolute_excess)
+                .map(|idx| idx as u64);
 
             let actual = bp.bwd_search(node_handle, relative_excess);
             assert_eq!(
@@ -443,13 +444,13 @@ fn test_parent() {
     for (idx, bit) in bv.iter().enumerate() {
         if bit == 1 {
             assert_eq!(
-                tree.parent(idx),
+                tree.parent(idx as u64),
                 head,
                 "parent of node {} is incorrect",
                 idx
             );
             stack.push(head);
-            head = Some(idx);
+            head = Some(idx as u64);
         } else {
             head = stack.pop().expect("stack underflow despite balanced tree");
         }
@@ -496,8 +497,8 @@ fn test_contiguous_index() {
     let rs: RsVec = bv.into();
 
     for (rank, index_in_bv) in rs.iter1().enumerate() {
-        assert_eq!(tree.node_index(index_in_bv), rank);
-        assert_eq!(tree.node_handle(rank), index_in_bv);
+        assert_eq!(tree.node_index(index_in_bv), rank as u64);
+        assert_eq!(tree.node_handle(rank as u64), index_in_bv);
     }
 }
 
@@ -535,7 +536,7 @@ fn test_is_leaf() {
     for (idx, is_leaf) in leaves.iter().enumerate() {
         // if the bit is 1, check if that node is a leaf. If it's 0, it's not a valid node handle.
         if bits[idx] == 1 {
-            assert_eq!(tree.is_leaf(idx), *is_leaf);
+            assert_eq!(tree.is_leaf(idx as u64), *is_leaf);
         }
     }
 }
@@ -756,8 +757,8 @@ fn fuzz_tree_navigation() {
     // fuzzing the tree navigation operations on an unbalanced tree
     // because those are easier to generate uniformly.
 
-    const L: usize = 1 << 14;
-    const L_BITS: usize = L * size_of::<u64>() * 8;
+    const L: u64 = 1 << 14;
+    const L_BITS: u64 = L * size_of::<u64>() as u64 * 8;
 
     // we generate a vector using a seeded random generator and check that every query works as expected
     let mut rng = StdRng::from_seed([0; 32]);
@@ -778,6 +779,7 @@ fn fuzz_tree_navigation() {
     let mut sibling_count_stack = Vec::new();
 
     tree.vec.iter().enumerate().for_each(|(idx, bit)| {
+        let idx = idx as u64;
         if bit == OPEN_PAREN {
             assert_eq!(tree.parent(idx), parent_stack.last().copied());
             assert_eq!(

--- a/src/trees/bp/tests.rs
+++ b/src/trees/bp/tests.rs
@@ -158,8 +158,8 @@ fn test_lookup_extreme_pop() {
 #[test]
 fn test_fwd_fuzzy() {
     // we're fuzzing forward search a bit
-    const L: usize = 1000;
-    const L_BITS: usize = L * size_of::<u64>() * 8;
+    const L: u64 = 1000;
+    const L_BITS: u64 = L * size_of::<u64>() * 8;
 
     // we generate a vector using a seeded random generator and check that every query works as expected
     let mut rng = StdRng::from_seed([0; 32]);
@@ -170,7 +170,7 @@ fn test_fwd_fuzzy() {
     }
 
     // pre-calculate all absolute excess values
-    let mut excess_values = vec![0i16; L_BITS];
+    let mut excess_values = vec![0i16; L_BITS as usize];
     let mut excess = 0;
     for (idx, bit) in bit_vec.iter().enumerate() {
         if bit == 1 {
@@ -188,7 +188,7 @@ fn test_fwd_fuzzy() {
     for relative_excess in [-3, -2, -1, 0, 1, 2, 3] {
         for node_handle in bp.vec.iter1() {
             let absolute_excess = bp.excess(node_handle) + relative_excess;
-            let expected = excess_values[node_handle + 1..]
+            let expected = excess_values[(node_handle + 1) as usize..]
                 .iter()
                 .position(|&excess| excess as i64 == absolute_excess)
                 .map(|i| i + node_handle + 1);

--- a/src/trees/mmt.rs
+++ b/src/trees/mmt.rs
@@ -47,6 +47,9 @@ impl MinMaxTree {
         }
 
         let num_leaves = bit_vec.len().div_ceil(block_size) as usize;
+        #[allow(clippy::cast_possible_truncation)] // only happens if available memory already exceeded
+        #[allow(clippy::cast_sign_loss)]
+        #[allow(clippy::cast_precision_loss)]
         let num_internal_nodes = max(1, (1 << (num_leaves as f64).log2().ceil() as usize) - 1);
 
         let mut nodes = vec![ExcessNode::default(); num_leaves + num_internal_nodes];

--- a/src/trees/mmt.rs
+++ b/src/trees/mmt.rs
@@ -170,7 +170,7 @@ impl MinMaxTree {
     /// Get the index of the left sibling of the node at `index` if it exists
     #[allow(clippy::unused_self)] // self is used for consistency with other methods
     pub(crate) fn left_sibling(&self, index: NonZeroUsize) -> Option<NonZeroUsize> {
-        if index.get() % 2 == 0 {
+        if index.get().is_multiple_of(2) {
             // index is at least 2
             NonZeroUsize::new(index.get() - 1)
         } else {

--- a/src/trees/mmt.rs
+++ b/src/trees/mmt.rs
@@ -46,6 +46,7 @@ impl MinMaxTree {
             return Self::default();
         }
 
+        #[allow(clippy::cast_possible_truncation)] // safe due to the division
         let num_leaves = bit_vec.len().div_ceil(block_size) as usize;
         #[allow(clippy::cast_possible_truncation)] // only happens if available memory already exceeded
         #[allow(clippy::cast_sign_loss)]
@@ -59,6 +60,7 @@ impl MinMaxTree {
 
         // bottom up construction
         for i in 0..bit_vec.len() {
+            #[allow(clippy::cast_possible_truncation)] // safe due to the division
             if i > 0 && i % block_size == 0 {
                 nodes[num_internal_nodes + (i / block_size) as usize - 1] = ExcessNode {
                     total: total_excess,

--- a/src/trees/mmt.rs
+++ b/src/trees/mmt.rs
@@ -41,12 +41,12 @@ pub(crate) struct MinMaxTree {
 }
 
 impl MinMaxTree {
-    pub(crate) fn excess_tree(bit_vec: &BitVec, block_size: usize) -> Self {
+    pub(crate) fn excess_tree(bit_vec: &BitVec, block_size: u64) -> Self {
         if bit_vec.is_empty() {
             return Self::default();
         }
 
-        let num_leaves = bit_vec.len().div_ceil(block_size);
+        let num_leaves = bit_vec.len().div_ceil(block_size) as usize;
         let num_internal_nodes = max(1, (1 << (num_leaves as f64).log2().ceil() as usize) - 1);
 
         let mut nodes = vec![ExcessNode::default(); num_leaves + num_internal_nodes];
@@ -57,7 +57,7 @@ impl MinMaxTree {
         // bottom up construction
         for i in 0..bit_vec.len() {
             if i > 0 && i % block_size == 0 {
-                nodes[num_internal_nodes + i / block_size - 1] = ExcessNode {
+                nodes[num_internal_nodes + (i / block_size) as usize - 1] = ExcessNode {
                     total: total_excess,
                     min: min_excess,
                     max: max_excess,

--- a/src/trees/mod.rs
+++ b/src/trees/mod.rs
@@ -122,6 +122,10 @@ pub trait LevelTree: Tree {
 ///
 /// Once the full tree has been visited, the caller must call [`build`] to create an instance of the
 /// implementing tree type.
+///
+/// [`enter_node`]: TreeBuilder::enter_node
+/// [`leave_node`]: TreeBuilder::leave_node
+/// [`build`]: TreeBuilder::build
 pub trait TreeBuilder {
     /// The tree type constructed with this interface
     type Tree;
@@ -139,5 +143,8 @@ pub trait TreeBuilder {
     /// (i.e. there are nodes for which [`leave_node`] has not been called,
     /// or there are more calls to `leave_node` than to [`enter_node`];
     /// the number of extraneous calls to `enter_node` is returned in the error).
+    ///
+    /// [`leave_node`]: Self::leave_node
+    /// [`enter_node`]: Self::enter_node
     fn build(self) -> Result<Self::Tree, i64>;
 }

--- a/src/trees/mod.rs
+++ b/src/trees/mod.rs
@@ -41,14 +41,14 @@ pub trait Tree {
 
     /// Convert a node handle into a contiguous index, allowing associated data to be stored in a vector.
     /// If `node` is not a valid node handle, the result is meaningless.
-    fn node_index(&self, node: Self::NodeHandle) -> usize;
+    fn node_index(&self, node: Self::NodeHandle) -> u64;
 
     /// Convert a contiguous index that enumerates all nodes into a node handle.
     /// This operation is the inverse of `node_index`.
     /// The index must be in the range `0..self.size()`.
     ///
     /// If the index is out of bounds, the behavior is unspecified.
-    fn node_handle(&self, index: usize) -> Self::NodeHandle;
+    fn node_handle(&self, index: u64) -> Self::NodeHandle;
 
     /// Returns true if the node is a leaf.
     /// If `node` is not a valid node handle, the result is meaningless.
@@ -63,7 +63,7 @@ pub trait Tree {
     fn depth(&self, node: Self::NodeHandle) -> u64;
 
     /// Returns the number of nodes in the tree.
-    fn size(&self) -> usize;
+    fn size(&self) -> u64;
 
     /// Returns true, if the tree has no nodes.
     fn is_empty(&self) -> bool {
@@ -81,7 +81,7 @@ pub trait SubtreeSize: Tree {
     ///
     /// Returns `None` if the `node` has no closing parenthesis (in an unbalanced parenthesis
     /// expression).
-    fn subtree_size(&self, node: Self::NodeHandle) -> Option<usize>;
+    fn subtree_size(&self, node: Self::NodeHandle) -> Option<u64>;
 }
 
 /// A trait for succinct tree data structures that support [`is_ancestor`] queries.

--- a/src/util/elias_fano_iter.rs
+++ b/src/util/elias_fano_iter.rs
@@ -16,6 +16,9 @@ macro_rules! gen_ef_iter_impl {
                     if Some(self.index) > self.back_index {
                         Err(std::num::NonZeroUsize::new(n).unwrap())
                     } else {
+                        // the following is limited in size by n, and `back_index` is `None` only if the vector is
+                        // empty, so a truncation is impossible
+                        #[allow(clippy::cast_possible_truncation)]
                         Err(std::num::NonZeroUsize::new(n - (self.back_index.as_ref().unwrap_or(&u64::MAX).wrapping_sub(self.index).wrapping_add(1)) as usize).unwrap())
                     }
                 } else {
@@ -47,7 +50,8 @@ macro_rules! gen_ef_iter_impl {
                 // since the cursors point to unconsumed items, we need to add 1
                 let remaining = *self.back_index.as_ref().unwrap() - self.index + 1;
                 if remaining < n as u64 {
-                    // since remaining < n, this cannot truncate
+                    // the following is limited in size by n, so a truncation is impossible
+                    #[allow(clippy::cast_possible_truncation)]
                     return Err(std::num::NonZeroUsize::new(n - remaining as usize).unwrap());
                 }
                 self.back_index = if self.back_index >= Some(n as u64) { self.back_index.map(|b| b - n as u64) } else { None };
@@ -140,19 +144,17 @@ macro_rules! gen_ef_iter_impl {
         }
 
         impl $(<$life>)? std::iter::ExactSizeIterator for $name $(<$life>)? {
+            // the check and panic guarantees panic on truncation
+            #[allow(clippy::cast_possible_truncation)]
             fn len(&self) -> usize {
-                // intentionally overflowing calculations to avoid branches on empty iterator
-                if size_of::<usize>() == size_of::<u64>() {
-                    (*self.back_index.as_ref().unwrap_or(&u64::MAX)).wrapping_sub(self.index).wrapping_add(1) as usize
-                } else {
-                    let len = (*self.back_index.as_ref().unwrap_or(&u64::MAX)).wrapping_sub(self.index).wrapping_add(1);
-                    if len > usize::MAX as u64 {
-                        // TODO document this panic
-                        panic!("vector length exceeds usize::MAX");
-                    }
-                    len as usize
+                // this check is hopefully eliminated on 64-bit architectures
+                if (*self.back_index.as_ref().unwrap_or(&u64::MAX)).wrapping_sub(self.index).wrapping_add(1)
+                    > usize::MAX as u64 {
+                    panic!("calling len() on an iterator containing more than usize::MAX elements is forbidden");
                 }
 
+                // intentionally overflowing calculations to avoid branches on empty iterator
+                (*self.back_index.as_ref().unwrap_or(&u64::MAX)).wrapping_sub(self.index).wrapping_add(1) as usize
             }
         }
 
@@ -229,6 +231,7 @@ macro_rules! impl_ef_iterator {
 
         impl EliasFanoVec {
             #[doc = concat!("Returns an iterator over the elements of `", stringify!($type), "`.")]
+            #[doc = "Note, if the iterator length exceeds `usize::MAX`, calling `len()` on it will panic ."]
             #[must_use]
             pub fn iter(&self) -> $bor<'_> {
                 $bor::new(self)

--- a/src/util/elias_fano_iter.rs
+++ b/src/util/elias_fano_iter.rs
@@ -92,6 +92,10 @@ macro_rules! gen_ef_iter_impl {
 
             /// Returns the exact number of elements that this iterator would iterate over. Does not
             /// call `next` internally.
+            ///
+            /// # Panics
+            /// If the vector contains more than `usize::MAX` elements, calling `count()` on the iterator will
+            /// cause it to panic.
             fn count(self) -> usize
             where
                 Self: Sized,

--- a/src/util/general_iter.rs
+++ b/src/util/general_iter.rs
@@ -101,6 +101,10 @@ macro_rules! gen_vector_iter_impl {
 
             /// Returns the exact number of elements that this iterator would iterate over. Does not
             /// call `next` internally.
+            ///
+            /// # Panics
+            /// If the vector contains more than `usize::MAX` elements, calling `count()` on the iterator will
+            /// cause it to panic.
             fn count(self) -> usize
             where
                 Self: Sized,

--- a/src/util/general_iter.rs
+++ b/src/util/general_iter.rs
@@ -32,14 +32,14 @@ macro_rules! gen_vector_iter_impl {
                     return Ok(());
                 }
 
-                if Some(self.index + n - 1) > self.back_index {
+                if Some(self.index + n as u64 - 1) > self.back_index {
                     if Some(self.index) > self.back_index {
                         Err(std::num::NonZeroUsize::new(n).unwrap())
                     } else {
                         Err(std::num::NonZeroUsize::new(n - (self.back_index.as_ref().unwrap_or(&u64::MAX).wrapping_sub(self.index).wrapping_add(1)) as usize).unwrap())
                     }
                 } else {
-                    self.index += n;
+                    self.index += n as u64;
                     Ok(())
                 }
             }

--- a/src/util/general_iter.rs
+++ b/src/util/general_iter.rs
@@ -36,7 +36,7 @@ macro_rules! gen_vector_iter_impl {
                     if Some(self.index) > self.back_index {
                         Err(std::num::NonZeroUsize::new(n).unwrap())
                     } else {
-                        Err(std::num::NonZeroUsize::new(n - (self.back_index.as_ref().unwrap_or(&usize::MAX).wrapping_sub(self.index).wrapping_add(1))).unwrap())
+                        Err(std::num::NonZeroUsize::new(n - (self.back_index.as_ref().unwrap_or(&u64::MAX).wrapping_sub(self.index).wrapping_add(1)) as usize).unwrap())
                     }
                 } else {
                     self.index += n;
@@ -62,10 +62,10 @@ macro_rules! gen_vector_iter_impl {
 
                 // since the cursors point to unconsumed items, we need to add 1
                 let remaining = *self.back_index.as_ref().unwrap() - self.index + 1;
-                if remaining < n {
-                    return Err(std::num::NonZeroUsize::new(n - remaining).unwrap());
+                if remaining < n as u64 {
+                    return Err(std::num::NonZeroUsize::new(n - remaining as usize).unwrap());
                 }
-                self.back_index = if self.back_index >= Some(n) { self.back_index.map(|b| b - n) } else { None };
+                self.back_index = if self.back_index >= Some(n as u64) { self.back_index.map(|b| b - n as u64) } else { None };
                 Ok(())
             }
 
@@ -126,7 +126,7 @@ macro_rules! gen_vector_iter_impl {
         impl $(<$life>)? std::iter::ExactSizeIterator for $name $(<$life>)? {
             fn len(&self) -> usize {
                 // intentionally overflowing calculations to avoid branches on empty iterator
-                (*self.back_index.as_ref().unwrap_or(&usize::MAX)).wrapping_sub(self.index).wrapping_add(1)
+                (*self.back_index.as_ref().unwrap_or(&u64::MAX)).wrapping_sub(self.index).wrapping_add(1) as usize
             }
         }
 
@@ -236,20 +236,20 @@ macro_rules! impl_vector_iterator {
         #[derive(Clone, Debug)]
         pub struct $own {
             vec: $type,
-            index: usize,
+            index: u64,
             // back index is none, iff it points to element -1 (i.e. element 0 has been consumed by
             // a call to next_back()). It can be Some(..) even if the iterator is empty
-            back_index: Option<usize>,
+            back_index: Option<u64>,
         }
 
         #[doc = concat!("A borrowing iterator for `", stringify!($type), "`.")]
         #[derive(Clone, Debug)]
         pub struct $bor<'a> {
             vec: &'a $type,
-            index: usize,
+            index: u64,
             // back index is none, iff it points to element -1 (i.e. element 0 has been consumed by
             // a call to next_back()). It can be Some(..) even if the iterator is empty
-            back_index: Option<usize>,
+            back_index: Option<u64>,
         }
 
         crate::util::gen_vector_iter_impl!($own, $type, $return_type, $get_unchecked, $get);

--- a/src/util/general_iter.rs
+++ b/src/util/general_iter.rs
@@ -36,6 +36,9 @@ macro_rules! gen_vector_iter_impl {
                     if Some(self.index) > self.back_index {
                         Err(std::num::NonZeroUsize::new(n).unwrap())
                     } else {
+                        // the following is limited in size by n, and `back_index` is `None` only if the vector is
+                        // empty, so a truncation is impossible
+                        #[allow(clippy::cast_possible_truncation)]
                         Err(std::num::NonZeroUsize::new(n - (self.back_index.as_ref().unwrap_or(&u64::MAX).wrapping_sub(self.index).wrapping_add(1)) as usize).unwrap())
                     }
                 } else {
@@ -63,6 +66,8 @@ macro_rules! gen_vector_iter_impl {
                 // since the cursors point to unconsumed items, we need to add 1
                 let remaining = *self.back_index.as_ref().unwrap() - self.index + 1;
                 if remaining < n as u64 {
+                    // the following is limited in size by n, so a truncation is impossible
+                    #[allow(clippy::cast_possible_truncation)]
                     return Err(std::num::NonZeroUsize::new(n - remaining as usize).unwrap());
                 }
                 self.back_index = if self.back_index >= Some(n as u64) { self.back_index.map(|b| b - n as u64) } else { None };
@@ -124,7 +129,15 @@ macro_rules! gen_vector_iter_impl {
         }
 
         impl $(<$life>)? std::iter::ExactSizeIterator for $name $(<$life>)? {
+            // the check and panic guarantees panic on truncation
+            #[allow(clippy::cast_possible_truncation)]
             fn len(&self) -> usize {
+                // this check is hopefully eliminated on 64-bit architectures
+                if (self.back_index.as_ref().unwrap_or(&u64::MAX)).wrapping_sub(self.index).wrapping_add(1)
+                    > usize::MAX as u64 {
+                    panic!("calling len() on an iterator containing more than usize::MAX elements is forbidden");
+                }
+
                 // intentionally overflowing calculations to avoid branches on empty iterator
                 (*self.back_index.as_ref().unwrap_or(&u64::MAX)).wrapping_sub(self.index).wrapping_add(1) as usize
             }
@@ -262,6 +275,8 @@ macro_rules! impl_vector_iterator {
         impl $type {
             #[doc = concat!("Returns an iterator over the elements of `", stringify!($type), "`.")]
             #[doc = concat!("The iterator returns `", stringify!($return_type), "` elements.")]
+            #[doc = "Note, if the iterator element type is larger than usize, calling `len()` on the \
+            iterator will panic if the iterator length exceeds `usize::MAX`."]
             #[must_use]
             pub fn iter(&self) -> $bor<'_> {
                 $bor::new(self)

--- a/src/wavelet/mod.rs
+++ b/src/wavelet/mod.rs
@@ -1942,7 +1942,7 @@ impl WaveletMatrix {
     /// assert_eq!(iter.collect::<Vec<_>>(), vec![1, 4, 4, 1, 2, 7]);
     /// ```
     #[must_use]
-    pub fn iter_u64(&self) -> Option<WaveletNumRefIter> {
+    pub fn iter_u64(&self) -> Option<WaveletNumRefIter<'_>> {
         if self.bits_per_element() > 64 {
             None
         } else {
@@ -1967,7 +1967,7 @@ impl WaveletMatrix {
     ///
     /// See also [`iter_sorted_u64`] for an iterator that yields `u64` elements.
     #[must_use]
-    pub fn iter_sorted(&self) -> WaveletSortedRefIter {
+    pub fn iter_sorted(&self) -> WaveletSortedRefIter<'_> {
         WaveletSortedRefIter::new(self)
     }
 
@@ -1993,7 +1993,7 @@ impl WaveletMatrix {
     /// assert_eq!(iter.collect::<Vec<_>>(), vec![1, 1, 2, 4, 4, 7]);
     /// ```
     #[must_use]
-    pub fn iter_sorted_u64(&self) -> Option<WaveletSortedNumRefIter> {
+    pub fn iter_sorted_u64(&self) -> Option<WaveletSortedNumRefIter<'_>> {
         if self.bits_per_element() > 64 {
             None
         } else {

--- a/src/wavelet/mod.rs
+++ b/src/wavelet/mod.rs
@@ -62,6 +62,10 @@ use std::ops::Range;
 /// ```
 ///
 /// [`RsVec`]: RsVec
+/// [`from_bit_vec`]: WaveletMatrix::from_bit_vec
+/// [`from_slice`]: WaveletMatrix::from_slice
+/// [`from_bit_vec_pc`]: WaveletMatrix::from_bit_vec_pc
+/// [`from_slice_pc`]: WaveletMatrix::from_slice_pc
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct WaveletMatrix {
@@ -1080,7 +1084,7 @@ impl WaveletMatrix {
     /// Get the `k`-th smallest element in the encoded sequence in the specified `range`,
     /// where `k = 0` returns the smallest element.
     /// The `range` is a half-open interval, meaning that the `end` index is exclusive.
-    /// The `k`-th smallest element is returned as a `BitVec`,
+    /// The `k`-th smallest element is returned as a [`BitVec`],
     /// where the least significant bit is the first element.
     ///
     /// Returns `None` if the `range` is out of bounds, or if `k` is greater than the size of the range.
@@ -1114,6 +1118,8 @@ impl WaveletMatrix {
     ///
     /// # Panics
     /// May panic if the `i` is out of bounds, or returns an empty bit vector.
+    ///
+    /// [`get_sorted`]: Self::get_sorted
     #[must_use]
     pub fn get_sorted_unchecked(&self, i: usize) -> BitVec {
         self.quantile_unchecked(0..self.len(), i)
@@ -1966,6 +1972,8 @@ impl WaveletMatrix {
     /// The iterator yields `BitVec` elements.
     ///
     /// See also [`iter_sorted_u64`] for an iterator that yields `u64` elements.
+    ///
+    /// [`iter_sorted_u64`]: Self::iter_sorted_u64
     #[must_use]
     pub fn iter_sorted(&self) -> WaveletSortedRefIter<'_> {
         WaveletSortedRefIter::new(self)

--- a/src/wavelet/tests.rs
+++ b/src/wavelet/tests.rs
@@ -37,9 +37,10 @@ fn test_wavelet_encoding_randomized() {
         let wavelet_prefix_counting =
             WaveletMatrix::from_bit_vec_pc(&BitVec::pack_sequence_u8(&data, 8), 8);
 
-        assert_eq!(wavelet.len(), data.len());
+        assert_eq!(wavelet.len(), data.len() as u64);
 
         for (i, v) in data.iter().enumerate() {
+            let i = i as u64;
             assert_eq!(wavelet.get_u64_unchecked(i), *v as u64);
             assert_eq!(wavelet_from_slice.get_u64_unchecked(i), *v as u64);
             assert_eq!(wavelet_prefix_counting.get_u64_unchecked(i), *v as u64);
@@ -138,7 +139,7 @@ fn test_rank_randomized() {
         let symbol_bit_vec = BitVec::pack_sequence_u8(&[symbol], 8);
         let mut rank = 0;
         for (i, v) in data.iter().enumerate() {
-            assert_eq!(wavelet.rank_unchecked(i, &symbol_bit_vec), rank);
+            assert_eq!(wavelet.rank_unchecked(i as u64, &symbol_bit_vec), rank);
             if *v == symbol {
                 rank += 1;
             }
@@ -230,10 +231,10 @@ fn test_quantile() {
 
     for (i, v) in sequence.iter().enumerate() {
         assert_eq!(
-            wavelet.quantile(0..10, i),
+            wavelet.quantile(0..10, i as u64),
             Some(BitVec::pack_sequence_u8(&[*v as u8], 4))
         );
-        assert_eq!(wavelet.quantile_u64(0..10, i), Some(*v));
+        assert_eq!(wavelet.quantile_u64(0..10, i as u64), Some(*v));
     }
 
     assert_eq!(wavelet.quantile(0..10, 10), None);
@@ -269,8 +270,8 @@ fn test_quantile_randomized() {
     let wavelet = WaveletMatrix::from_bit_vec(&BitVec::pack_sequence_u8(&data, 8), 8);
 
     for _ in 0..1000 {
-        let range_i = rng.gen_range(0..data.len());
-        let range_j = rng.gen_range(0..data.len());
+        let range_i = rng.gen_range(0..data.len() as u64);
+        let range_j = rng.gen_range(0..data.len() as u64);
         let range = min(range_i, range_j)..max(range_i, range_j);
 
         let k = if range.is_empty() {
@@ -279,7 +280,7 @@ fn test_quantile_randomized() {
             rng.gen_range(range.clone()) - range.start
         };
 
-        let mut range_data = data[range.clone()].to_vec();
+        let mut range_data = data[range.start as usize..range.end as usize].to_vec();
         range_data.sort_unstable();
 
         assert_eq!(
@@ -287,7 +288,7 @@ fn test_quantile_randomized() {
             if range.is_empty() {
                 None
             } else {
-                Some(range_data[k] as u64)
+                Some(range_data[k as usize] as u64)
             }
         );
         assert_eq!(


### PR DESCRIPTION
Bit vectors can hold more bits than `usize::MAX`, and therefore all bit-indexing and length calculation should be performed with `u64` instead.

This has some unfortunate side effects that need to be addressed
- [x] ExactSizeIterator does not support iterators with more than `usize::MAX` elements. Code paths where this can be circumvented should be special-cased for <64 bit plattforms, and where it can't there should be documentation about potential panics.
- [x] `take()` and `skip()` in iterators takes a usize, which means subtrees in BP that exceed 2^32 bits cannot be handled properly.
- [x] When converting from `u64` to `usize` for indexing byte-based structures, care must be taken that conversions happen in the correct order