### PR TITLE
change `const` to `static` for lookup tables

### DIFF
--- a/benches/bp.rs
+++ b/benches/bp.rs
@@ -1,5 +1,3 @@
-#![allow(long_running_const_eval)]
-
 use criterion::{black_box, criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion};
 use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};

--- a/src/trees/bp/lookup.rs
+++ b/src/trees/bp/lookup.rs
@@ -48,7 +48,7 @@ const LOOKUP_MAX_VALUE: u32 = u8::MAX as u32;
 ///
 /// The rest of the bits are zero.
 #[allow(long_running_const_eval)]
-const PAREN_BLOCK_LOOKUP: [EncodedTableType; 1 << LOOKUP_BLOCK_SIZE] = calculate_lookup_table();
+static PAREN_BLOCK_LOOKUP: [EncodedTableType; 1 << LOOKUP_BLOCK_SIZE] = calculate_lookup_table();
 
 /// Offset to add to encoded excess values, so negative numbers are stored as positive integers, reducing
 /// encoding complexity

--- a/src/trees/bp/lookup_query.rs
+++ b/src/trees/bp/lookup_query.rs
@@ -22,14 +22,14 @@ const LOOKUP_MAX_VALUE: u32 = u8::MAX as u32;
 /// to dual-encode negative excess), and another 51 bits for all 17 queries that may end in this block
 /// (-8 to 8 relative excess).
 #[allow(long_running_const_eval)]
-const PAREN_BLOCK_LOOKUP_FWD: [u64; 1 << LOOKUP_BLOCK_SIZE] = calculate_lookup_table(true);
+static PAREN_BLOCK_LOOKUP_FWD: [u64; 1 << LOOKUP_BLOCK_SIZE] = calculate_lookup_table(true);
 
 /// Encoded bwd query results for all possible 8-bit blocks.
 /// The encoding reserves 10 bits for minimum and maximum excess (shifted by 8 bits so we don't have
 /// to dual-encode negative excess), and another 51 bits for all 17 queries that may end in this block
 /// (-8 to 8 relative excess).
 #[allow(long_running_const_eval)]
-const PAREN_BLOCK_LOOKUP_BWD: [u64; 1 << LOOKUP_BLOCK_SIZE] = calculate_lookup_table(false);
+static PAREN_BLOCK_LOOKUP_BWD: [u64; 1 << LOOKUP_BLOCK_SIZE] = calculate_lookup_table(false);
 
 /// Bitmask for one of the lookup values.
 const ENCODING_MASK: u64 = 0b11111;

--- a/src/trees/bp/mod.rs
+++ b/src/trees/bp/mod.rs
@@ -85,7 +85,6 @@ use lookup_query::{process_block_bwd, process_block_fwd, LOOKUP_BLOCK_SIZE};
 /// The high-level approach to building a tree is to use the [`BpBuilder`] to construct the tree
 /// using depth-first traversal of all its nodes.
 /// ```rust
-/// # #![allow(long_running_const_eval)] // for some reason this is needed for test cases
 /// use vers_vecs::{BitVec, BpBuilder, BpTree, TreeBuilder, Tree};
 ///
 /// let mut builder = BpBuilder::<512>::new();
@@ -119,7 +118,6 @@ use lookup_query::{process_block_bwd, process_block_fwd, LOOKUP_BLOCK_SIZE};
 /// This is also how trees with unbalanced parenthesis expressions can be constructed.
 ///
 /// ```rust
-/// # #![allow(long_running_const_eval)]
 /// use vers_vecs::{BitVec, BpTree, Tree};
 /// let bv = BitVec::pack_sequence_u8(&[0b1101_0111, 0b0010_0100], 8);
 /// let tree = BpTree::<4>::from_bit_vector(bv);


### PR DESCRIPTION
All lookup tables for BP are `const`, which makes the compiler inline them. I changed it t use `static` instead, which is the intended way of defining lookup tables, obviously.

This also fixes the elusive issue where "some" downstream crates (i.e., tests and benchmarks, as well as LTO crates I guess) warned about long_running_const_eval even though the lookup tables shouldn't be evaluated for them (but were due to inlining).