### PR TITLE
Change backing structs of our Data Structures to Box<[_]>

### DIFF
--- a/migrate.md
+++ b/migrate.md
@@ -19,3 +19,9 @@ This affects `BitVec`, `RsVec`, `EliasFano`, `SparseRsVec`, `BpTree`, and `Wavel
 This changes the parameter and return types of various functions on the affected types from `usize` to `u64`.
 The only adverse effect is that `len()` and `count()` of iterators over these data structures may panic if the
 iterator has more than `usize::MAX` elements.
+
+## Changed Backing Structures
+`RsVec`, `SparseRmq`, and `FastRmq` now use `Box<[_]>` instead of `Vec<_>` as backing structs, which reduces the stack 
+footprint.
+This breaks the serde-compatibility with already serialized data.
+It also changes the `Deref` implementation of the RMQ structs, which previously returned `Vec<_>`.

--- a/migrate.md
+++ b/migrate.md
@@ -11,3 +11,11 @@ The following structures and functions were renamed
 - `BitVec::from_bits` to `BitVec::from_bits_u8`
 - module `fast_rs_vec` to `rs`
 - module `elias_fano` to `ef`
+
+## Changed Index Type
+All vector types that operate on bits or sub-byte words are now indexed by `u64` instead of `usize`, 
+allowing full utilization of the memory in 32-bit architectures.
+This affects `BitVec`, `RsVec`, `EliasFano`, `SparseRsVec`, `BpTree`, and `WaveletMatrix`
+This changes the parameter and return types of various functions on the affected types from `usize` to `u64`.
+The only adverse effect is that `len()` and `count()` of iterators over these data structures may panic if the
+iterator has more than `usize::MAX` elements.

--- a/src/bit_vec/rs/mod.rs
+++ b/src/bit_vec/rs/mod.rs
@@ -85,11 +85,11 @@ struct SelectSuperBlockDescriptor {
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct RsVec {
-    data: Vec<u64>,
+    data: Box<[u64]>,
     len: u64,
-    blocks: Vec<BlockDescriptor>,
-    super_blocks: Vec<SuperBlockDescriptor>,
-    select_blocks: Vec<SelectSuperBlockDescriptor>,
+    blocks: Box<[BlockDescriptor]>,
+    super_blocks: Box<[SuperBlockDescriptor]>,
+    select_blocks: Box<[SelectSuperBlockDescriptor]>,
     pub(crate) rank0: u64,
     pub(crate) rank1: u64,
 }
@@ -214,11 +214,11 @@ impl RsVec {
         total_zeros += current_zeros;
 
         RsVec {
-            data: vec.data,
+            data: vec.data.into_boxed_slice(),
             len: vec.len,
-            blocks,
-            super_blocks,
-            select_blocks,
+            blocks: blocks.into_boxed_slice(),
+            super_blocks: super_blocks.into_boxed_slice(),
+            select_blocks: select_blocks.into_boxed_slice(),
             rank0: total_zeros,
             rank1: vec.len - total_zeros,
         }
@@ -409,7 +409,7 @@ impl RsVec {
     #[must_use]
     pub fn into_bit_vec(self) -> BitVec {
         BitVec {
-            data: self.data,
+            data: self.data.into_vec(),
             len: self.len,
         }
     }

--- a/src/rmq/binary_rmq/mod.rs
+++ b/src/rmq/binary_rmq/mod.rs
@@ -29,12 +29,12 @@ use std::ops::{Deref, RangeBounds};
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SparseRmq {
-    data: Vec<u64>,
+    data: Box<[u64]>,
 
     // store indices relative to start of range. There is no way to have ranges exceeding 2^32 bits
     // but since we have fast_rmq for larger inputs, which does not have any downsides at that point,
     // we can just use u32 here (which gains cache efficiency for both implementations).
-    results: Vec<u32>,
+    results: Box<[u32]>,
 }
 
 impl SparseRmq {
@@ -102,7 +102,10 @@ impl SparseRmq {
             }
         }
 
-        Self { data, results }
+        Self {
+            data: data.into_boxed_slice(),
+            results: results.into_boxed_slice(),
+        }
     }
 
     /// Convenience function for [`SparseRmq::range_min`] for using range operators.
@@ -170,7 +173,7 @@ impl SparseRmq {
 /// indexing syntax on the RMQ data structure to access the underlying data, as well as iterators,
 /// etc.
 impl Deref for SparseRmq {
-    type Target = Vec<u64>;
+    type Target = Box<[u64]>;
 
     fn deref(&self) -> &Self::Target {
         &self.data

--- a/src/rmq/fast_rmq/mod.rs
+++ b/src/rmq/fast_rmq/mod.rs
@@ -78,10 +78,10 @@ struct Block {
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SmallRmq {
-    data: Vec<u64>,
+    data: Box<[u64]>,
     block_minima: SparseRmq,
-    block_min_indices: Vec<u8>,
-    blocks: Vec<Block>,
+    block_min_indices: Box<[u8]>,
+    blocks: Box<[Block]>,
 }
 
 impl SmallRmq {
@@ -141,10 +141,10 @@ impl SmallRmq {
         });
 
         Self {
-            data,
+            data: data.into_boxed_slice(),
             block_minima: SparseRmq::from_vec(block_minima),
-            block_min_indices,
-            blocks,
+            block_min_indices: block_min_indices.into_boxed_slice(),
+            blocks: blocks.into_boxed_slice(),
         }
     }
 
@@ -291,7 +291,7 @@ impl SmallRmq {
 /// indexing syntax on the RMQ data structure to access the underlying data, as well as iterators,
 /// etc.
 impl Deref for SmallRmq {
-    type Target = Vec<u64>;
+    type Target = Box<[u64]>;
 
     fn deref(&self) -> &Self::Target {
         &self.data


### PR DESCRIPTION
Our data structures are immutable, so we don't need `Vec` to store our data.
This saves some space on stack, but also breaks serde compatibility and the `Deref` implementations of the RMQ data structures