### PR TITLE
Add predecessor and successor functions  to RsVec

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,10 @@ harness = false
 name = "elias_fano_construction"
 harness = false
 
+[[bench]]
+name = "rs_successor"
+harness = false
+
 [profile.bench]
 lto = true
 

--- a/benches/rs_successor.rs
+++ b/benches/rs_successor.rs
@@ -1,0 +1,38 @@
+//! Benchmark compare performance of bit-vector successor call with select(rank(p) + 1).
+
+use std::hint::black_box;
+use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion};
+use rand::distributions::{Distribution, Uniform};
+
+mod common;
+
+fn bench_successor(b: &mut Criterion) {
+    let mut rng = rand::thread_rng();
+
+    let mut group = b.benchmark_group("Successor");
+    group.plot_config(common::plot_config());
+
+    for l in common::SIZES {
+        let bit_vec = common::construct_vers_vec(&mut rng, l);
+        let sample = Uniform::new(0, bit_vec.len() / 4);
+        group.bench_with_input(BenchmarkId::new("successor", l), &l, |b, _| {
+            b.iter_batched(
+                || sample.sample(&mut rng),
+                |e| black_box(bit_vec.successor1(e)),
+                BatchSize::SmallInput,
+            )
+        });
+
+        group.bench_with_input(BenchmarkId::new("select", l), &l, |b, _| {
+            b.iter_batched(
+                || sample.sample(&mut rng),
+                |e| black_box(bit_vec.select1(bit_vec.rank1(e) + 1)),
+                BatchSize::SmallInput,
+            )
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_successor);
+criterion_main!(benches);

--- a/src/bit_vec/fast_rs_vec/mod.rs
+++ b/src/bit_vec/fast_rs_vec/mod.rs
@@ -503,6 +503,40 @@ impl RsVec {
             + self.super_blocks.len() * size_of::<SuperBlockDescriptor>()
             + self.select_blocks.len() * size_of::<SelectSuperBlockDescriptor>()
     }
+
+    #[must_use]
+    pub fn successor0(&self, pos: usize) -> usize {
+        let rank = self.rank0(pos);
+        let bit = self.get_unchecked(pos);
+        if bit == 0 {
+            return self.select0(rank + 1);
+        }
+
+        self.select0(rank)
+    }
+
+    #[must_use]
+    pub fn successor1(&self, pos: usize) -> usize {
+        let rank = self.rank1(pos);
+        let bit = self.get_unchecked(pos);
+        if bit == 1 {
+            return self.select1(rank + 1)
+        }
+
+        self.select1(rank)
+    }
+
+    #[must_use]
+    pub fn predecessor0(&self, pos: usize) -> usize {
+        let rank = self.rank0(pos);
+        self.select0(rank - 1)
+    }
+
+    #[must_use]
+    pub fn predecessor1(&self, pos: usize) -> usize {
+        let rank = self.rank1(pos);
+        self.select1(rank - 1)
+    }
 }
 
 impl_vector_iterator! { RsVec, RsVecIter, RsVecRefIter }

--- a/src/bit_vec/fast_rs_vec/mod.rs
+++ b/src/bit_vec/fast_rs_vec/mod.rs
@@ -503,40 +503,6 @@ impl RsVec {
             + self.super_blocks.len() * size_of::<SuperBlockDescriptor>()
             + self.select_blocks.len() * size_of::<SelectSuperBlockDescriptor>()
     }
-
-    #[must_use]
-    pub fn successor0(&self, pos: usize) -> usize {
-        let rank = self.rank0(pos);
-        let bit = self.get_unchecked(pos);
-        if bit == 0 {
-            return self.select0(rank + 1);
-        }
-
-        self.select0(rank)
-    }
-
-    #[must_use]
-    pub fn successor1(&self, pos: usize) -> usize {
-        let rank = self.rank1(pos);
-        let bit = self.get_unchecked(pos);
-        if bit == 1 {
-            return self.select1(rank + 1)
-        }
-
-        self.select1(rank)
-    }
-
-    #[must_use]
-    pub fn predecessor0(&self, pos: usize) -> usize {
-        let rank = self.rank0(pos);
-        self.select0(rank - 1)
-    }
-
-    #[must_use]
-    pub fn predecessor1(&self, pos: usize) -> usize {
-        let rank = self.rank1(pos);
-        self.select1(rank - 1)
-    }
 }
 
 impl_vector_iterator! { RsVec, RsVecIter, RsVecRefIter }

--- a/src/bit_vec/fast_rs_vec/select.rs
+++ b/src/bit_vec/fast_rs_vec/select.rs
@@ -438,8 +438,7 @@ impl super::RsVec {
         {
             // successor is in current block
             if block_idx % (BLOCKS_PER_SUPERBLOCK) == (BLOCKS_PER_SUPERBLOCK - 1)
-                || self.blocks.len() > block_idx + 1
-                    && self.blocks[block_idx + 1].zeros as usize > rank
+                || self.blocks[block_idx + 1].zeros as usize > rank
             {
                 rank -= self.blocks[block_idx].zeros as usize;
                 return Some(self.search_word_in_block0(rank, block_idx) as u64);
@@ -493,10 +492,9 @@ impl super::RsVec {
             let block_at_super_block = super_block_idx * (BLOCKS_PER_SUPERBLOCK);
             // successor is in current block
             if block_idx % (BLOCKS_PER_SUPERBLOCK) == BLOCKS_PER_SUPERBLOCK - 1
-                || self.blocks.len() > block_idx + 1
-                    && (block_idx + 1 - block_at_super_block) * BLOCK_SIZE
-                        - self.blocks[block_idx + 1].zeros as usize
-                        > rank
+                || (block_idx + 1 - block_at_super_block) * BLOCK_SIZE
+                    - self.blocks[block_idx + 1].zeros as usize
+                    > rank
             {
                 let block_ones = (block_idx - block_at_super_block) * BLOCK_SIZE
                     - self.blocks[block_idx].zeros as usize;

--- a/src/bit_vec/fast_rs_vec/select.rs
+++ b/src/bit_vec/fast_rs_vec/select.rs
@@ -417,6 +417,20 @@ impl super::RsVec {
     /// However, this method exploits the fact that on average, the position is expected to be near
     /// `pos`.
     /// If this assumption is known to be false, calling `select0(rank0(pos) + 1)` is more efficient.
+    ///
+    /// # Example
+    /// ```
+    /// use vers_vecs::{BitVec, RsVec};
+    ///
+    /// let mut bv = BitVec::from_ones(8);
+    /// bv.flip_bit(1);
+    /// bv.flip_bit(4);
+    /// let rs = RsVec::from(bv);
+    ///
+    /// assert_eq!(rs.successor0(0), Some(1));
+    /// assert_eq!(rs.successor0(1), Some(4));
+    /// assert_eq!(rs.successor0(4), None);
+    /// ```
     #[must_use]
     pub fn successor0(&self, pos: usize) -> Option<u64> {
         if self.is_empty() {
@@ -463,6 +477,20 @@ impl super::RsVec {
     /// However, this method exploits the fact that on average, the position is expected to be near
     /// `pos`.
     /// If this assumption is known to be false, calling `select1(rank1(pos) + 1)` is more efficient.
+    ///
+    /// # Example
+    /// ```
+    /// use vers_vecs::{BitVec, RsVec};
+    ///
+    /// let mut bv = BitVec::from_zeros(8);
+    /// bv.flip_bit(1);
+    /// bv.flip_bit(4);
+    /// let rs = RsVec::from(bv);
+    ///
+    /// assert_eq!(rs.successor1(0), Some(1));
+    /// assert_eq!(rs.successor1(1), Some(4));
+    /// assert_eq!(rs.successor1(4), None);
+    /// ```
     #[must_use]
     pub fn successor1(&self, pos: usize) -> Option<u64> {
         if self.is_empty() {
@@ -521,6 +549,20 @@ impl super::RsVec {
     /// However, this method exploits the fact that on average, the position is expected to be near
     /// `pos`.
     /// If this assumption is known to be false, calling `select0(rank0(pos) - 1)` is more efficient.
+    ///
+    /// # Example
+    /// ```
+    /// use vers_vecs::{BitVec, RsVec};
+    ///
+    /// let mut bv = BitVec::from_ones(8);
+    /// bv.flip_bit(1);
+    /// bv.flip_bit(4);
+    /// let rs = RsVec::from(bv);
+    ///
+    /// assert_eq!(rs.predecessor0(5), Some(4));
+    /// assert_eq!(rs.predecessor0(4), Some(1));
+    /// assert_eq!(rs.predecessor0(1), None);
+    /// ```
     #[must_use]
     pub fn predecessor0(&self, pos: usize) -> Option<u64> {
         if self.is_empty() {
@@ -560,6 +602,20 @@ impl super::RsVec {
     /// However, this method exploits the fact that on average, the position is expected to be near
     /// `pos`.
     /// If this assumption is known to be false, calling `select1(rank1(pos) - 1)` is more efficient.
+    ///
+    /// # Example
+    /// ```
+    /// use vers_vecs::{BitVec, RsVec};
+    ///
+    /// let mut bv = BitVec::from_zeros(8);
+    /// bv.flip_bit(1);
+    /// bv.flip_bit(4);
+    /// let rs = RsVec::from(bv);
+    ///
+    /// assert_eq!(rs.predecessor1(5), Some(4));
+    /// assert_eq!(rs.predecessor1(4), Some(1));
+    /// assert_eq!(rs.predecessor1(1), None);
+    /// ```
     #[must_use]
     pub fn predecessor1(&self, pos: usize) -> Option<u64> {
         if self.is_empty() {

--- a/src/bit_vec/fast_rs_vec/select.rs
+++ b/src/bit_vec/fast_rs_vec/select.rs
@@ -419,16 +419,19 @@ impl super::RsVec {
         let mut block_idx = pos / BLOCK_SIZE;
         let super_block_idx = pos / SUPER_BLOCK_SIZE;
 
-        if self.super_blocks[super_block_idx].zeros < rank {
-            rank -= self.super_blocks[super_block_idx].zeros;
-
+        if self.super_blocks.len() > (SUPER_BLOCK_SIZE + 1)
+            && self.super_blocks[SUPER_BLOCK_SIZE + 1].zeros > rank
+        {
             // successor is in current block
-            if (self.blocks[block_idx].zeros as usize) < rank {
+            if block_idx % (BLOCKS_PER_SUPERBLOCK) == (BLOCKS_PER_SUPERBLOCK - 1)
+                || self.blocks.len() > block_idx + 1
+                    && self.blocks[block_idx + 1].zeros as usize > rank
+            {
                 rank -= self.blocks[block_idx].zeros as usize;
                 return self.search_word_in_block0(rank, block_idx);
             }
 
-            block_idx = super_block_idx * (SUPER_BLOCK_SIZE / BLOCK_SIZE);
+            block_idx = super_block_idx * (BLOCKS_PER_SUPERBLOCK);
             self.search_block0(rank, &mut block_idx);
 
             rank -= self.blocks[block_idx].zeros as usize;
@@ -449,17 +452,26 @@ impl super::RsVec {
         let mut block_idx = pos / BLOCK_SIZE;
         let super_block_idx = pos / SUPER_BLOCK_SIZE;
 
-        let super_block_ones =
-            (super_block_idx * SUPER_BLOCK_SIZE) - self.super_blocks[super_block_idx].zeros;
+        if self.super_blocks.len() > (super_block_idx + 1)
+            && (super_block_idx + 1) * SUPER_BLOCK_SIZE
+                - self.super_blocks[super_block_idx + 1].zeros
+                > rank
+        {
+            let super_block_ones =
+                (super_block_idx * SUPER_BLOCK_SIZE) - self.super_blocks[super_block_idx].zeros;
 
-        if super_block_ones < rank {
             rank -= super_block_ones;
 
-            let block_at_super_block = super_block_idx * (SUPER_BLOCK_SIZE / BLOCK_SIZE);
-            let block_ones = (block_idx - block_at_super_block) * BLOCK_SIZE
-                - self.blocks[block_idx].zeros as usize;
+            let block_at_super_block = super_block_idx * (BLOCKS_PER_SUPERBLOCK);
             // successor is in current block
-            if block_ones < rank {
+            if block_idx % (BLOCKS_PER_SUPERBLOCK) == BLOCKS_PER_SUPERBLOCK - 1
+                || self.blocks.len() > block_idx + 1
+                    && (block_idx + 1 - block_at_super_block) * BLOCK_SIZE
+                        - self.blocks[block_idx + 1].zeros as usize
+                        > rank
+            {
+                let block_ones = (block_idx - block_at_super_block) * BLOCK_SIZE
+                    - self.blocks[block_idx].zeros as usize;
                 rank -= block_ones;
                 return self.search_word_in_block1(rank, block_idx);
             }
@@ -493,7 +505,7 @@ impl super::RsVec {
                 return self.search_word_in_block0(rank, block_idx);
             }
 
-            block_idx = super_block_idx * (SUPER_BLOCK_SIZE / BLOCK_SIZE);
+            block_idx = super_block_idx * (BLOCKS_PER_SUPERBLOCK);
             self.search_block0(rank, &mut block_idx);
 
             rank -= self.blocks[block_idx].zeros as usize;
@@ -519,7 +531,7 @@ impl super::RsVec {
         if super_block_ones < rank {
             rank -= super_block_ones;
 
-            let block_at_super_block = super_block_idx * (SUPER_BLOCK_SIZE / BLOCK_SIZE);
+            let block_at_super_block = super_block_idx * (BLOCKS_PER_SUPERBLOCK);
             let block_ones = (block_idx - block_at_super_block) * BLOCK_SIZE
                 - self.blocks[block_idx].zeros as usize;
             // predecessor is in current block

--- a/src/bit_vec/fast_rs_vec/select.rs
+++ b/src/bit_vec/fast_rs_vec/select.rs
@@ -117,24 +117,6 @@ impl super::RsVec {
             boundary /= 2);
     }
 
-    /// Search for the block that contains the given rank (relative to the superblock) by linearly
-    /// traversing the super-block. The block_index is mutated until it points to the correct block,
-    /// or the last block in the super-block if the rank is not located within the super-block.
-    /// The block_index may be anywhere in the superblock.
-    fn search_block0_linearly(
-        &self,
-        rank: usize,
-        block_index: &mut usize,
-    ) {
-        *block_index += 1;
-        while (*block_index + 1) % BLOCKS_PER_SUPERBLOCK != 0 {
-            if self.blocks[*block_index + 1].zeros as usize > rank {
-                return;
-            }
-            *block_index += 1;
-        }
-    }
-
     /// Search for the word in the block that contains the rank, return the index of the rank-th
     /// zero bit in the word.
     /// This function is called by the ``select0``, ``iter::select_next_0`` and ``iter::select_next_0_back`` functions.
@@ -357,25 +339,6 @@ impl super::RsVec {
             boundary /= 2);
     }
 
-    /// Search for the block that contains the given rank (relative to the superblock) by linearly
-    /// traversing the super-block. The block_index is mutated until it points to the correct block,
-    /// or the last block in the super-block if the rank is not located within the super-block.
-    /// The block_index may be anywhere in the superblock.
-    fn search_block1_linearly(
-        &self,
-        rank: usize,
-        block_at_superblock: usize,
-        block_index: &mut usize,
-    ) {
-        *block_index += 1;
-        while (*block_index + 1) % BLOCKS_PER_SUPERBLOCK != 0 {
-            if (*block_index + 1 - block_at_superblock) * BLOCK_SIZE - self.blocks[*block_index + 1].zeros as usize > rank {
-                return;
-            }
-            *block_index += 1;
-        }
-    }
-
     /// Search for the word in the block that contains the rank, return the index of the rank-th
     /// zero bit in the word.
     /// This function is called by the ``select1``, ``iter::select_next_1`` and ``iter::select_next_1_back`` functions.
@@ -483,7 +446,7 @@ impl super::RsVec {
             }
 
             block_idx = super_block_idx * (BLOCKS_PER_SUPERBLOCK);
-            self.search_block0_linearly(rank, &mut block_idx);
+            self.search_block0(rank, &mut block_idx);
 
             rank -= self.blocks[block_idx].zeros as usize;
 
@@ -541,8 +504,8 @@ impl super::RsVec {
                 return Some(self.search_word_in_block1(rank, block_idx) as u64);
             }
 
-            // block_idx = block_at_super_block;
-            self.search_block1_linearly(rank, block_at_super_block, &mut block_idx);
+            block_idx = block_at_super_block;
+            self.search_block1(rank, block_at_super_block, &mut block_idx);
             rank -= (block_idx - block_at_super_block) * BLOCK_SIZE
                 - self.blocks[block_idx].zeros as usize;
 

--- a/src/bit_vec/fast_rs_vec/select.rs
+++ b/src/bit_vec/fast_rs_vec/select.rs
@@ -377,7 +377,8 @@ impl super::RsVec {
     }
 
     /// Search for the superblock that contains the rank.
-    /// This function is called by the ``select1``, ``iter::select_next_1`` and ``iter::select_next_1_back`` functions.
+    /// This function is called by the ``select1``, ``iter::select_next_1`` and
+    /// ``iter::select_next_1_back`` functions.
     ///
     /// # Arguments
     /// * `super_block` - the index of the superblock to start the search from, this is the
@@ -408,7 +409,14 @@ impl super::RsVec {
         super_block
     }
 
-    /// Returns the position of the 0-bit after the given index `pos`
+    /// Returns the position of the next 0-bit after the given index `pos`.
+    /// If there is no 0-bit after the given index, `None` is returned.
+    ///
+    /// The function is in principle equivalent to calling `select0(rank0(pos) + 1)` (excluding
+    /// edge cases).
+    /// However, this method exploits the fact that on average, the position is expected to be near
+    /// `pos`.
+    /// If this assumption is known to be false, calling `select0(rank0(pos) + 1)` is more efficient.
     #[must_use]
     pub fn successor0(&self, pos: usize) -> Option<u64> {
         let rank = self.rank0(pos);
@@ -442,7 +450,14 @@ impl super::RsVec {
         }
     }
 
-    /// Returns the position of the 1-bit after the given index `pos`
+    /// Returns the position of the next 1-bit after the given index `pos`.
+    /// If there is no 1-bit after the given index, `None` is returned.
+    ///
+    /// The function is in principle equivalent to calling `select1(rank1(pos) + 1)` (excluding
+    /// edge cases).
+    /// However, this method exploits the fact that on average, the position is expected to be near
+    /// `pos`.
+    /// If this assumption is known to be false, calling `select1(rank1(pos) + 1)` is more efficient.
     #[must_use]
     pub fn successor1(&self, pos: usize) -> Option<u64> {
         let rank = self.rank1(pos);
@@ -487,7 +502,14 @@ impl super::RsVec {
         }
     }
 
-    /// Returns the position of the 0-bit before the given index `pos`
+    /// Returns the position of the last 0-bit before the given index `pos`.
+    /// If there is no 0-bit before the given index, `None` is returned.
+    ///
+    /// The function is in principle equivalent to calling `select0(rank0(pos) - 1)` (excluding
+    /// edge cases).
+    /// However, this method exploits the fact that on average, the position is expected to be near
+    /// `pos`.
+    /// If this assumption is known to be false, calling `select0(rank0(pos) - 1)` is more efficient.
     #[must_use]
     pub fn predecessor0(&self, pos: usize) -> Option<u64> {
         let mut rank = self.rank0(pos) - 1;
@@ -515,7 +537,14 @@ impl super::RsVec {
         }
     }
 
-    /// Returns the position of the 1-bit before the given index `pos`
+    /// Returns the position of the last 1-bit before the given index `pos`.
+    /// If there is no 1-bit before the given index, `None` is returned.
+    ///
+    /// The function is in principle equivalent to calling `select1(rank1(pos) - 1)` (excluding
+    /// edge cases).
+    /// However, this method exploits the fact that on average, the position is expected to be near
+    /// `pos`.
+    /// If this assumption is known to be false, calling `select1(rank1(pos) - 1)` is more efficient.
     #[must_use]
     pub fn predecessor1(&self, pos: usize) -> Option<u64> {
         let mut rank = self.rank1(pos) - 1;

--- a/src/bit_vec/fast_rs_vec/select.rs
+++ b/src/bit_vec/fast_rs_vec/select.rs
@@ -407,4 +407,64 @@ impl super::RsVec {
 
         super_block
     }
+
+    /// Returns the position of the 0-bit after the given index `pos`
+    #[must_use]
+    pub fn successor0(&self, pos: usize) -> usize {
+        let rank = self.rank0(pos);
+        let bit = self.get_unchecked(pos);
+        if bit == 0 {
+            return self.select0(rank + 1);
+        }
+
+        self.select0(rank)
+    }
+
+    /// Returns the position of the 1-bit after the given index `pos`
+    #[must_use]
+    pub fn successor1(&self, pos: usize) -> usize {
+        let rank = self.rank1(pos);
+        let bit = self.get_unchecked(pos);
+        if bit == 1 {
+            return self.select1(rank + 1);
+        }
+
+        self.select1(rank)
+    }
+
+    /// Returns the position of the 0-bit before the given index `pos`
+    #[must_use]
+    pub fn predecessor0(&self, pos: usize) -> usize {
+        let mut rank = self.rank0(pos) - 1;
+        //self.select0(rank - 1)
+
+        let mut block_idx = pos / BLOCK_SIZE;
+        let super_block_idx = pos / SUPER_BLOCK_SIZE;
+
+        if self.super_blocks[super_block_idx].zeros < rank {
+            rank -= self.super_blocks[super_block_idx].zeros;
+
+            // predecessor is in current block
+            if (self.blocks[block_idx].zeros as usize) < rank {
+                rank -= self.blocks[block_idx].zeros as usize;
+                return self.search_word_in_block0(rank, block_idx);
+            }
+
+            block_idx = super_block_idx * (SUPER_BLOCK_SIZE / BLOCK_SIZE);
+            self.search_block0(rank, &mut block_idx);
+
+            rank -= self.blocks[block_idx].zeros as usize;
+
+            self.search_word_in_block0(rank, block_idx)
+        } else {
+            self.select0(rank)
+        }
+    }
+
+    /// Returns the position of the 1-bit before the given index `pos`
+    #[must_use]
+    pub fn predecessor1(&self, pos: usize) -> usize {
+        let rank = self.rank1(pos);
+        self.select1(rank - 1)
+    }
 }

--- a/src/bit_vec/fast_rs_vec/select.rs
+++ b/src/bit_vec/fast_rs_vec/select.rs
@@ -410,7 +410,7 @@ impl super::RsVec {
 
     /// Returns the position of the 0-bit after the given index `pos`
     #[must_use]
-    pub fn successor0(&self, pos: usize) -> usize {
+    pub fn successor0(&self, pos: usize) -> Option<u64> {
         let rank = self.rank0(pos);
         let bit = self.get_unchecked(pos);
 
@@ -428,7 +428,7 @@ impl super::RsVec {
                     && self.blocks[block_idx + 1].zeros as usize > rank
             {
                 rank -= self.blocks[block_idx].zeros as usize;
-                return self.search_word_in_block0(rank, block_idx);
+                return Some(self.search_word_in_block0(rank, block_idx) as u64);
             }
 
             block_idx = super_block_idx * (BLOCKS_PER_SUPERBLOCK);
@@ -436,15 +436,15 @@ impl super::RsVec {
 
             rank -= self.blocks[block_idx].zeros as usize;
 
-            self.search_word_in_block0(rank, block_idx)
+            Some(self.search_word_in_block0(rank, block_idx) as u64)
         } else {
-            self.select0(rank)
+            Some(self.select0(rank) as u64)
         }
     }
 
     /// Returns the position of the 1-bit after the given index `pos`
     #[must_use]
-    pub fn successor1(&self, pos: usize) -> usize {
+    pub fn successor1(&self, pos: usize) -> Option<u64> {
         let rank = self.rank1(pos);
         let bit = self.get_unchecked(pos);
         let mut rank = if bit == 1 { rank + 1 } else { rank };
@@ -473,7 +473,7 @@ impl super::RsVec {
                 let block_ones = (block_idx - block_at_super_block) * BLOCK_SIZE
                     - self.blocks[block_idx].zeros as usize;
                 rank -= block_ones;
-                return self.search_word_in_block1(rank, block_idx);
+                return Some(self.search_word_in_block1(rank, block_idx) as u64);
             }
 
             block_idx = block_at_super_block;
@@ -481,17 +481,16 @@ impl super::RsVec {
             rank -= (block_idx - block_at_super_block) * BLOCK_SIZE
                 - self.blocks[block_idx].zeros as usize;
 
-            self.search_word_in_block1(rank, block_idx)
+            Some(self.search_word_in_block1(rank, block_idx) as u64)
         } else {
-            self.select1(rank)
+            Some(self.select1(rank) as u64)
         }
     }
 
     /// Returns the position of the 0-bit before the given index `pos`
     #[must_use]
-    pub fn predecessor0(&self, pos: usize) -> usize {
+    pub fn predecessor0(&self, pos: usize) -> Option<u64> {
         let mut rank = self.rank0(pos) - 1;
-        //self.select0(rank - 1)
 
         let mut block_idx = pos / BLOCK_SIZE;
         let super_block_idx = pos / SUPER_BLOCK_SIZE;
@@ -502,7 +501,7 @@ impl super::RsVec {
             // predecessor is in current block
             if (self.blocks[block_idx].zeros as usize) < rank {
                 rank -= self.blocks[block_idx].zeros as usize;
-                return self.search_word_in_block0(rank, block_idx);
+                return Some(self.search_word_in_block0(rank, block_idx) as u64);
             }
 
             block_idx = super_block_idx * (BLOCKS_PER_SUPERBLOCK);
@@ -510,17 +509,16 @@ impl super::RsVec {
 
             rank -= self.blocks[block_idx].zeros as usize;
 
-            self.search_word_in_block0(rank, block_idx)
+            Some(self.search_word_in_block0(rank, block_idx) as u64)
         } else {
-            self.select0(rank)
+            Some(self.select0(rank) as u64)
         }
     }
 
     /// Returns the position of the 1-bit before the given index `pos`
     #[must_use]
-    pub fn predecessor1(&self, pos: usize) -> usize {
+    pub fn predecessor1(&self, pos: usize) -> Option<u64> {
         let mut rank = self.rank1(pos) - 1;
-        //self.select1(rank - 1)
 
         let mut block_idx = pos / BLOCK_SIZE;
         let super_block_idx = pos / SUPER_BLOCK_SIZE;
@@ -537,7 +535,7 @@ impl super::RsVec {
             // predecessor is in current block
             if block_ones < rank {
                 rank -= block_ones;
-                return self.search_word_in_block1(rank, block_idx);
+                return Some(self.search_word_in_block1(rank, block_idx) as u64);
             }
 
             block_idx = block_at_super_block;
@@ -545,9 +543,9 @@ impl super::RsVec {
             rank -= (block_idx - block_at_super_block) * BLOCK_SIZE
                 - self.blocks[block_idx].zeros as usize;
 
-            self.search_word_in_block1(rank, block_idx)
+            Some(self.search_word_in_block1(rank, block_idx) as u64)
         } else {
-            self.select1(rank)
+            Some(self.select1(rank) as u64)
         }
     }
 }

--- a/src/bit_vec/fast_rs_vec/select.rs
+++ b/src/bit_vec/fast_rs_vec/select.rs
@@ -419,10 +419,16 @@ impl super::RsVec {
     /// If this assumption is known to be false, calling `select0(rank0(pos) + 1)` is more efficient.
     #[must_use]
     pub fn successor0(&self, pos: usize) -> Option<u64> {
-        let rank = self.rank0(pos);
-        let bit = self.get_unchecked(pos);
+        if self.is_empty() {
+            return None;
+        }
 
-        let mut rank = if bit == 0 { rank + 1 } else { rank };
+        let rank = self.rank0(pos);
+        let mut rank = if self.get(pos)? == 0 { rank + 1 } else { rank };
+
+        if rank >= self.rank0 {
+            return None;
+        }
 
         let mut block_idx = pos / BLOCK_SIZE;
         let super_block_idx = pos / SUPER_BLOCK_SIZE;
@@ -460,9 +466,16 @@ impl super::RsVec {
     /// If this assumption is known to be false, calling `select1(rank1(pos) + 1)` is more efficient.
     #[must_use]
     pub fn successor1(&self, pos: usize) -> Option<u64> {
+        if self.is_empty() {
+            return None;
+        }
+
         let rank = self.rank1(pos);
-        let bit = self.get_unchecked(pos);
-        let mut rank = if bit == 1 { rank + 1 } else { rank };
+        let mut rank = if self.get(pos)? == 1 { rank + 1 } else { rank };
+
+        if rank >= self.rank1 {
+            return None;
+        }
 
         let mut block_idx = pos / BLOCK_SIZE;
         let super_block_idx = pos / SUPER_BLOCK_SIZE;
@@ -512,7 +525,11 @@ impl super::RsVec {
     /// If this assumption is known to be false, calling `select0(rank0(pos) - 1)` is more efficient.
     #[must_use]
     pub fn predecessor0(&self, pos: usize) -> Option<u64> {
-        let mut rank = self.rank0(pos) - 1;
+        if self.is_empty() {
+            return None;
+        }
+
+        let mut rank = self.rank0(pos).checked_sub(1)?;
 
         let mut block_idx = pos / BLOCK_SIZE;
         let super_block_idx = pos / SUPER_BLOCK_SIZE;
@@ -547,7 +564,11 @@ impl super::RsVec {
     /// If this assumption is known to be false, calling `select1(rank1(pos) - 1)` is more efficient.
     #[must_use]
     pub fn predecessor1(&self, pos: usize) -> Option<u64> {
-        let mut rank = self.rank1(pos) - 1;
+        if self.is_empty() {
+            return None;
+        }
+
+        let mut rank = self.rank1(pos).checked_sub(1)?;
 
         let mut block_idx = pos / BLOCK_SIZE;
         let super_block_idx = pos / SUPER_BLOCK_SIZE;

--- a/src/bit_vec/fast_rs_vec/select.rs
+++ b/src/bit_vec/fast_rs_vec/select.rs
@@ -422,7 +422,7 @@ impl super::RsVec {
         if self.super_blocks[super_block_idx].zeros < rank {
             rank -= self.super_blocks[super_block_idx].zeros;
 
-            // predecessor is in current block
+            // successor is in current block
             if (self.blocks[block_idx].zeros as usize) < rank {
                 rank -= self.blocks[block_idx].zeros as usize;
                 return self.search_word_in_block0(rank, block_idx);
@@ -444,11 +444,35 @@ impl super::RsVec {
     pub fn successor1(&self, pos: usize) -> usize {
         let rank = self.rank1(pos);
         let bit = self.get_unchecked(pos);
-        if bit == 1 {
-            return self.select1(rank + 1);
-        }
+        let mut rank = if bit == 1 { rank + 1 } else { rank };
 
-        self.select1(rank)
+        let mut block_idx = pos / BLOCK_SIZE;
+        let super_block_idx = pos / SUPER_BLOCK_SIZE;
+
+        let super_block_ones =
+            (super_block_idx * SUPER_BLOCK_SIZE) - self.super_blocks[super_block_idx].zeros;
+
+        if super_block_ones < rank {
+            rank -= super_block_ones;
+
+            let block_at_super_block = super_block_idx * (SUPER_BLOCK_SIZE / BLOCK_SIZE);
+            let block_ones = (block_idx - block_at_super_block) * BLOCK_SIZE
+                - self.blocks[block_idx].zeros as usize;
+            // successor is in current block
+            if block_ones < rank {
+                rank -= block_ones;
+                return self.search_word_in_block1(rank, block_idx);
+            }
+
+            block_idx = block_at_super_block;
+            self.search_block1(rank, block_at_super_block, &mut block_idx);
+            rank -= (block_idx - block_at_super_block) * BLOCK_SIZE
+                - self.blocks[block_idx].zeros as usize;
+
+            self.search_word_in_block1(rank, block_idx)
+        } else {
+            self.select1(rank)
+        }
     }
 
     /// Returns the position of the 0-bit before the given index `pos`
@@ -483,7 +507,35 @@ impl super::RsVec {
     /// Returns the position of the 1-bit before the given index `pos`
     #[must_use]
     pub fn predecessor1(&self, pos: usize) -> usize {
-        let rank = self.rank1(pos);
-        self.select1(rank - 1)
+        let mut rank = self.rank1(pos) - 1;
+        //self.select1(rank - 1)
+
+        let mut block_idx = pos / BLOCK_SIZE;
+        let super_block_idx = pos / SUPER_BLOCK_SIZE;
+
+        let super_block_ones =
+            (super_block_idx * SUPER_BLOCK_SIZE) - self.super_blocks[super_block_idx].zeros;
+
+        if super_block_ones < rank {
+            rank -= super_block_ones;
+
+            let block_at_super_block = super_block_idx * (SUPER_BLOCK_SIZE / BLOCK_SIZE);
+            let block_ones = (block_idx - block_at_super_block) * BLOCK_SIZE
+                - self.blocks[block_idx].zeros as usize;
+            // predecessor is in current block
+            if block_ones < rank {
+                rank -= block_ones;
+                return self.search_word_in_block1(rank, block_idx);
+            }
+
+            block_idx = block_at_super_block;
+            self.search_block1(rank, block_at_super_block, &mut block_idx);
+            rank -= (block_idx - block_at_super_block) * BLOCK_SIZE
+                - self.blocks[block_idx].zeros as usize;
+
+            self.search_word_in_block1(rank, block_idx)
+        } else {
+            self.select1(rank)
+        }
     }
 }

--- a/src/bit_vec/fast_rs_vec/select.rs
+++ b/src/bit_vec/fast_rs_vec/select.rs
@@ -413,11 +413,30 @@ impl super::RsVec {
     pub fn successor0(&self, pos: usize) -> usize {
         let rank = self.rank0(pos);
         let bit = self.get_unchecked(pos);
-        if bit == 0 {
-            return self.select0(rank + 1);
-        }
 
-        self.select0(rank)
+        let mut rank = if bit == 0 { rank + 1 } else { rank };
+
+        let mut block_idx = pos / BLOCK_SIZE;
+        let super_block_idx = pos / SUPER_BLOCK_SIZE;
+
+        if self.super_blocks[super_block_idx].zeros < rank {
+            rank -= self.super_blocks[super_block_idx].zeros;
+
+            // predecessor is in current block
+            if (self.blocks[block_idx].zeros as usize) < rank {
+                rank -= self.blocks[block_idx].zeros as usize;
+                return self.search_word_in_block0(rank, block_idx);
+            }
+
+            block_idx = super_block_idx * (SUPER_BLOCK_SIZE / BLOCK_SIZE);
+            self.search_block0(rank, &mut block_idx);
+
+            rank -= self.blocks[block_idx].zeros as usize;
+
+            self.search_word_in_block0(rank, block_idx)
+        } else {
+            self.select0(rank)
+        }
     }
 
     /// Returns the position of the 1-bit after the given index `pos`

--- a/src/bit_vec/fast_rs_vec/select.rs
+++ b/src/bit_vec/fast_rs_vec/select.rs
@@ -117,6 +117,24 @@ impl super::RsVec {
             boundary /= 2);
     }
 
+    /// Search for the block that contains the given rank (relative to the superblock) by linearly
+    /// traversing the super-block. The block_index is mutated until it points to the correct block,
+    /// or the last block in the super-block if the rank is not located within the super-block.
+    /// The block_index may be anywhere in the superblock.
+    fn search_block0_linearly(
+        &self,
+        rank: usize,
+        block_index: &mut usize,
+    ) {
+        *block_index += 1;
+        while (*block_index + 1) % BLOCKS_PER_SUPERBLOCK != 0 {
+            if self.blocks[*block_index + 1].zeros as usize > rank {
+                return;
+            }
+            *block_index += 1;
+        }
+    }
+
     /// Search for the word in the block that contains the rank, return the index of the rank-th
     /// zero bit in the word.
     /// This function is called by the ``select0``, ``iter::select_next_0`` and ``iter::select_next_0_back`` functions.
@@ -339,6 +357,25 @@ impl super::RsVec {
             boundary /= 2);
     }
 
+    /// Search for the block that contains the given rank (relative to the superblock) by linearly
+    /// traversing the super-block. The block_index is mutated until it points to the correct block,
+    /// or the last block in the super-block if the rank is not located within the super-block.
+    /// The block_index may be anywhere in the superblock.
+    fn search_block1_linearly(
+        &self,
+        rank: usize,
+        block_at_superblock: usize,
+        block_index: &mut usize,
+    ) {
+        *block_index += 1;
+        while (*block_index + 1) % BLOCKS_PER_SUPERBLOCK != 0 {
+            if (*block_index + 1 - block_at_superblock) * BLOCK_SIZE - self.blocks[*block_index + 1].zeros as usize > rank {
+                return;
+            }
+            *block_index += 1;
+        }
+    }
+
     /// Search for the word in the block that contains the rank, return the index of the rank-th
     /// zero bit in the word.
     /// This function is called by the ``select1``, ``iter::select_next_1`` and ``iter::select_next_1_back`` functions.
@@ -446,7 +483,7 @@ impl super::RsVec {
             }
 
             block_idx = super_block_idx * (BLOCKS_PER_SUPERBLOCK);
-            self.search_block0(rank, &mut block_idx);
+            self.search_block0_linearly(rank, &mut block_idx);
 
             rank -= self.blocks[block_idx].zeros as usize;
 
@@ -504,8 +541,8 @@ impl super::RsVec {
                 return Some(self.search_word_in_block1(rank, block_idx) as u64);
             }
 
-            block_idx = block_at_super_block;
-            self.search_block1(rank, block_at_super_block, &mut block_idx);
+            // block_idx = block_at_super_block;
+            self.search_block1_linearly(rank, block_at_super_block, &mut block_idx);
             rank -= (block_idx - block_at_super_block) * BLOCK_SIZE
                 - self.blocks[block_idx].zeros as usize;
 

--- a/src/bit_vec/fast_rs_vec/tests.rs
+++ b/src/bit_vec/fast_rs_vec/tests.rs
@@ -1400,17 +1400,35 @@ fn test_predecessor1_and_successor1() {
     bv.flip_bit(SUPER_BLOCK_SIZE + 1);
     let rs = RsVec::from_bit_vec(bv);
 
-    assert_eq!(rs.predecessor1(SUPER_BLOCK_SIZE + 2), Some(SUPER_BLOCK_SIZE as u64 + 1));
-    assert_eq!(rs.predecessor1(SUPER_BLOCK_SIZE + 1), Some(SUPER_BLOCK_SIZE as u64));
-    assert_eq!(rs.predecessor1(SUPER_BLOCK_SIZE), Some(SUPER_BLOCK_SIZE as u64 - 1));
-    assert_eq!(rs.predecessor1(SUPER_BLOCK_SIZE - 2), Some(BLOCK_SIZE as u64 + 1));
+    assert_eq!(
+        rs.predecessor1(SUPER_BLOCK_SIZE + 2),
+        Some(SUPER_BLOCK_SIZE as u64 + 1)
+    );
+    assert_eq!(
+        rs.predecessor1(SUPER_BLOCK_SIZE + 1),
+        Some(SUPER_BLOCK_SIZE as u64)
+    );
+    assert_eq!(
+        rs.predecessor1(SUPER_BLOCK_SIZE),
+        Some(SUPER_BLOCK_SIZE as u64 - 1)
+    );
+    assert_eq!(
+        rs.predecessor1(SUPER_BLOCK_SIZE - 2),
+        Some(BLOCK_SIZE as u64 + 1)
+    );
 
     assert_eq!(rs.predecessor1(4), Some(3));
 
     assert_eq!(rs.successor1(SUPER_BLOCK_SIZE + 2), None);
     assert_eq!(rs.successor1(SUPER_BLOCK_SIZE + 1), None);
-    assert_eq!(rs.successor1(SUPER_BLOCK_SIZE), Some(SUPER_BLOCK_SIZE as u64 + 1));
-    assert_eq!(rs.successor1(SUPER_BLOCK_SIZE - 2), Some(SUPER_BLOCK_SIZE as u64 - 1));
+    assert_eq!(
+        rs.successor1(SUPER_BLOCK_SIZE),
+        Some(SUPER_BLOCK_SIZE as u64 + 1)
+    );
+    assert_eq!(
+        rs.successor1(SUPER_BLOCK_SIZE - 2),
+        Some(SUPER_BLOCK_SIZE as u64 - 1)
+    );
     assert_eq!(rs.successor1(BLOCK_SIZE - 2), Some(BLOCK_SIZE as u64));
     assert_eq!(rs.successor1(4), Some(5u64));
 }
@@ -1428,18 +1446,36 @@ fn test_predecessor0_and_successor0() {
     bv.flip_bit(SUPER_BLOCK_SIZE + 1);
     let rs = RsVec::from_bit_vec(bv);
 
-    assert_eq!(rs.predecessor0(SUPER_BLOCK_SIZE + 2), Some(SUPER_BLOCK_SIZE as u64 + 1));
-    assert_eq!(rs.predecessor0(SUPER_BLOCK_SIZE + 1), Some(SUPER_BLOCK_SIZE as u64));
-    assert_eq!(rs.predecessor0(SUPER_BLOCK_SIZE), Some(SUPER_BLOCK_SIZE as u64 - 1));
-    assert_eq!(rs.predecessor0(SUPER_BLOCK_SIZE - 2), Some(BLOCK_SIZE as u64 + 1));
+    assert_eq!(
+        rs.predecessor0(SUPER_BLOCK_SIZE + 2),
+        Some(SUPER_BLOCK_SIZE as u64 + 1)
+    );
+    assert_eq!(
+        rs.predecessor0(SUPER_BLOCK_SIZE + 1),
+        Some(SUPER_BLOCK_SIZE as u64)
+    );
+    assert_eq!(
+        rs.predecessor0(SUPER_BLOCK_SIZE),
+        Some(SUPER_BLOCK_SIZE as u64 - 1)
+    );
+    assert_eq!(
+        rs.predecessor0(SUPER_BLOCK_SIZE - 2),
+        Some(BLOCK_SIZE as u64 + 1)
+    );
 
     assert_eq!(rs.predecessor0(4), Some(3));
     assert_eq!(rs.predecessor0(3), Some(1));
 
     assert_eq!(rs.successor0(SUPER_BLOCK_SIZE + 2), None);
     assert_eq!(rs.successor0(SUPER_BLOCK_SIZE + 1), None);
-    assert_eq!(rs.successor0(SUPER_BLOCK_SIZE), Some(SUPER_BLOCK_SIZE as u64 + 1));
-    assert_eq!(rs.successor0(SUPER_BLOCK_SIZE - 2), Some(SUPER_BLOCK_SIZE as u64 - 1));
+    assert_eq!(
+        rs.successor0(SUPER_BLOCK_SIZE),
+        Some(SUPER_BLOCK_SIZE as u64 + 1)
+    );
+    assert_eq!(
+        rs.successor0(SUPER_BLOCK_SIZE - 2),
+        Some(SUPER_BLOCK_SIZE as u64 - 1)
+    );
     assert_eq!(rs.successor0(BLOCK_SIZE - 2), Some(BLOCK_SIZE as u64));
     assert_eq!(rs.successor0(4), Some(5));
     assert_eq!(rs.successor0(3), Some(5));
@@ -1494,7 +1530,7 @@ fn test_empty_vec_succ_pred() {
 fn test_pred_randomized() {
     let mut rng = StdRng::seed_from_u64(0);
 
-    let mut bv = BitVec::from_zeros(4 * SUPER_BLOCK_SIZE);
+    let mut bv = BitVec::from_zeros(4 * SUPER_BLOCK_SIZE + BLOCK_SIZE / 3);
     for i in 0..bv.len() {
         if rng.gen_bool(0.5) {
             bv.flip_bit(i)
@@ -1526,7 +1562,7 @@ fn test_pred_randomized() {
 fn test_succ_randomized() {
     let mut rng = StdRng::seed_from_u64(0);
 
-    let mut bv = BitVec::from_zeros(4 * SUPER_BLOCK_SIZE);
+    let mut bv = BitVec::from_zeros(4 * SUPER_BLOCK_SIZE + BLOCK_SIZE / 3);
     for i in 0..bv.len() {
         if rng.gen_bool(0.5) {
             bv.flip_bit(i)

--- a/src/bit_vec/fast_rs_vec/tests.rs
+++ b/src/bit_vec/fast_rs_vec/tests.rs
@@ -1494,7 +1494,7 @@ fn test_empty_vec_succ_pred() {
 fn test_pred_randomized() {
     let mut rng = StdRng::seed_from_u64(0);
 
-    let mut bv = BitVec::with_capacity(4 * SUPER_BLOCK_SIZE);
+    let mut bv = BitVec::from_zeros(4 * SUPER_BLOCK_SIZE);
     for i in 0..bv.len() {
         if rng.gen_bool(0.5) {
             bv.flip_bit(i)
@@ -1526,7 +1526,7 @@ fn test_pred_randomized() {
 fn test_succ_randomized() {
     let mut rng = StdRng::seed_from_u64(0);
 
-    let mut bv = BitVec::with_capacity(4 * SUPER_BLOCK_SIZE);
+    let mut bv = BitVec::from_zeros(4 * SUPER_BLOCK_SIZE);
     for i in 0..bv.len() {
         if rng.gen_bool(0.5) {
             bv.flip_bit(i)
@@ -1535,8 +1535,8 @@ fn test_succ_randomized() {
 
     let rs = RsVec::from_bit_vec(bv.clone());
 
-    let mut last_0 = rs.select0(rs.rank0) as u64;
-    let mut last_1 = rs.select1(rs.rank1) as u64;
+    let mut last_0 = rs.select0(rs.rank0 - 1) as u64;
+    let mut last_1 = rs.select1(rs.rank1 - 1) as u64;
 
     for i in (0..bv.len()).rev() {
         if last_0 > i as u64 {

--- a/src/bit_vec/fast_rs_vec/tests.rs
+++ b/src/bit_vec/fast_rs_vec/tests.rs
@@ -1444,3 +1444,48 @@ fn test_predecessor0_and_successor0() {
     assert_eq!(rs.successor0(4), Some(5));
     assert_eq!(rs.successor0(3), Some(5));
 }
+
+#[test]
+fn test_non_existing_predecessor() {
+    let bv = BitVec::from_zeros(2 * SUPER_BLOCK_SIZE);
+    let rs = RsVec::from_bit_vec(bv);
+    assert_eq!(rs.predecessor1(0), None);
+    assert_eq!(rs.predecessor1(SUPER_BLOCK_SIZE), None);
+    assert_eq!(rs.predecessor1(2 * SUPER_BLOCK_SIZE - 1), None);
+    assert_eq!(rs.predecessor1(2 * SUPER_BLOCK_SIZE), None);
+
+    let bv = BitVec::from_ones(2 * SUPER_BLOCK_SIZE);
+    let rs = RsVec::from_bit_vec(bv);
+    assert_eq!(rs.predecessor0(0), None);
+    assert_eq!(rs.predecessor0(SUPER_BLOCK_SIZE), None);
+    assert_eq!(rs.predecessor0(2 * SUPER_BLOCK_SIZE - 1), None);
+    assert_eq!(rs.predecessor0(2 * SUPER_BLOCK_SIZE), None);
+}
+
+#[test]
+fn test_non_existing_successor() {
+    let bv = BitVec::from_zeros(2 * SUPER_BLOCK_SIZE);
+    let rs = RsVec::from_bit_vec(bv);
+    assert_eq!(rs.successor1(0), None);
+    assert_eq!(rs.successor1(SUPER_BLOCK_SIZE), None);
+    assert_eq!(rs.successor1(2 * SUPER_BLOCK_SIZE - 1), None);
+    assert_eq!(rs.successor1(2 * SUPER_BLOCK_SIZE), None);
+
+    let bv = BitVec::from_ones(2 * SUPER_BLOCK_SIZE);
+    let rs = RsVec::from_bit_vec(bv);
+    assert_eq!(rs.successor0(0), None);
+    assert_eq!(rs.successor0(SUPER_BLOCK_SIZE), None);
+    assert_eq!(rs.successor0(2 * SUPER_BLOCK_SIZE - 1), None);
+    assert_eq!(rs.successor0(2 * SUPER_BLOCK_SIZE), None);
+}
+
+#[test]
+fn test_empty_vec_succ_pred() {
+    let bv = BitVec::new();
+    let rs = RsVec::from_bit_vec(bv);
+
+    assert_eq!(rs.successor1(0), None);
+    assert_eq!(rs.predecessor1(0), None);
+    assert_eq!(rs.successor0(0), None);
+    assert_eq!(rs.successor1(0), None);
+}

--- a/src/bit_vec/fast_rs_vec/tests.rs
+++ b/src/bit_vec/fast_rs_vec/tests.rs
@@ -1489,3 +1489,67 @@ fn test_empty_vec_succ_pred() {
     assert_eq!(rs.successor0(0), None);
     assert_eq!(rs.successor1(0), None);
 }
+
+#[test]
+fn test_pred_randomized() {
+    let mut rng = StdRng::seed_from_u64(0);
+
+    let mut bv = BitVec::with_capacity(4 * SUPER_BLOCK_SIZE);
+    for i in 0..bv.len() {
+        if rng.gen_bool(0.5) {
+            bv.flip_bit(i)
+        }
+    }
+
+    let rs = RsVec::from_bit_vec(bv.clone());
+
+    let mut last_0 = rs.select0(0) as u64;
+    let mut last_1 = rs.select1(0) as u64;
+
+    for i in 0..bv.len() {
+        if last_0 < i as u64 {
+            assert_eq!(rs.predecessor0(i), Some(last_0));
+        }
+        if last_1 < i as u64 {
+            assert_eq!(rs.predecessor1(i), Some(last_1));
+        }
+
+        if bv.is_bit_set_unchecked(i) {
+            last_1 = i as u64;
+        } else {
+            last_0 = i as u64;
+        }
+    }
+}
+
+#[test]
+fn test_succ_randomized() {
+    let mut rng = StdRng::seed_from_u64(0);
+
+    let mut bv = BitVec::with_capacity(4 * SUPER_BLOCK_SIZE);
+    for i in 0..bv.len() {
+        if rng.gen_bool(0.5) {
+            bv.flip_bit(i)
+        }
+    }
+
+    let rs = RsVec::from_bit_vec(bv.clone());
+
+    let mut last_0 = rs.select0(rs.rank0) as u64;
+    let mut last_1 = rs.select1(rs.rank1) as u64;
+
+    for i in (0..bv.len()).rev() {
+        if last_0 > i as u64 {
+            assert_eq!(rs.successor0(i), Some(last_0));
+        }
+        if last_1 > i as u64 {
+            assert_eq!(rs.successor1(i), Some(last_1));
+        }
+
+        if bv.is_bit_set_unchecked(i) {
+            last_1 = i as u64;
+        } else {
+            last_0 = i as u64;
+        }
+    }
+}

--- a/src/bit_vec/fast_rs_vec/tests.rs
+++ b/src/bit_vec/fast_rs_vec/tests.rs
@@ -1400,22 +1400,19 @@ fn test_predecessor1_and_successor1() {
     bv.flip_bit(SUPER_BLOCK_SIZE + 1);
     let rs = RsVec::from_bit_vec(bv);
 
+    assert_eq!(rs.predecessor1(SUPER_BLOCK_SIZE + 2), SUPER_BLOCK_SIZE + 1);
+    assert_eq!(rs.predecessor1(SUPER_BLOCK_SIZE + 1), SUPER_BLOCK_SIZE);
+    assert_eq!(rs.predecessor1(SUPER_BLOCK_SIZE), SUPER_BLOCK_SIZE - 1);
     assert_eq!(rs.predecessor1(SUPER_BLOCK_SIZE - 2), BLOCK_SIZE + 1);
-    assert_eq!(rs.successor1(SUPER_BLOCK_SIZE - 2), SUPER_BLOCK_SIZE - 1);
 
     assert_eq!(rs.predecessor1(4), 3);
-    assert_eq!(rs.successor1(4), 5);
 
-    //let mut iter = rs.iter1();
-    //assert_eq!(iter.next(), Some(1));
-    //assert_eq!(iter.next(), Some(3));
-    //assert_eq!(iter.next(), Some(5));
-    //assert_eq!(iter.next(), Some(BLOCK_SIZE));
-    //assert_eq!(iter.next(), Some(BLOCK_SIZE + 1));
-    //assert_eq!(iter.next(), Some(SUPER_BLOCK_SIZE - 1));
-    //assert_eq!(iter.next(), Some(SUPER_BLOCK_SIZE));
-    //assert_eq!(iter.next(), Some(SUPER_BLOCK_SIZE + 1));
-    //assert_eq!(iter.next(), None);
+    assert_eq!(rs.successor1(SUPER_BLOCK_SIZE + 2), rs.len());
+    assert_eq!(rs.successor1(SUPER_BLOCK_SIZE + 1), rs.len());
+    assert_eq!(rs.successor1(SUPER_BLOCK_SIZE), SUPER_BLOCK_SIZE + 1);
+    assert_eq!(rs.successor1(SUPER_BLOCK_SIZE - 2), SUPER_BLOCK_SIZE - 1);
+    assert_eq!(rs.successor1(BLOCK_SIZE - 2), BLOCK_SIZE);
+    assert_eq!(rs.successor1(4), 5);
 }
 
 #[test]
@@ -1431,20 +1428,17 @@ fn test_predecessor0_and_successor0() {
     bv.flip_bit(SUPER_BLOCK_SIZE + 1);
     let rs = RsVec::from_bit_vec(bv);
 
+    assert_eq!(rs.predecessor0(SUPER_BLOCK_SIZE + 2), SUPER_BLOCK_SIZE + 1);
+    assert_eq!(rs.predecessor0(SUPER_BLOCK_SIZE + 1), SUPER_BLOCK_SIZE);
+    assert_eq!(rs.predecessor0(SUPER_BLOCK_SIZE), SUPER_BLOCK_SIZE - 1);
     assert_eq!(rs.predecessor0(SUPER_BLOCK_SIZE - 2), BLOCK_SIZE + 1);
-    assert_eq!(rs.successor0(SUPER_BLOCK_SIZE - 2), SUPER_BLOCK_SIZE - 1);
 
     assert_eq!(rs.predecessor0(4), 3);
-    assert_eq!(rs.successor0(4), 5);
 
-    //let mut iter = rs.iter0();
-    //assert_eq!(iter.next(), Some(1));
-    //assert_eq!(iter.next(), Some(3));
-    //assert_eq!(iter.next(), Some(5));
-    //assert_eq!(iter.next(), Some(BLOCK_SIZE));
-    //assert_eq!(iter.next(), Some(BLOCK_SIZE + 1));
-    //assert_eq!(iter.next(), Some(SUPER_BLOCK_SIZE - 1));
-    //assert_eq!(iter.next(), Some(SUPER_BLOCK_SIZE));
-    //assert_eq!(iter.next(), Some(SUPER_BLOCK_SIZE + 1));
-    //assert_eq!(iter.next(), None);
+    assert_eq!(rs.successor0(SUPER_BLOCK_SIZE + 2), rs.len());
+    assert_eq!(rs.successor0(SUPER_BLOCK_SIZE + 1), rs.len());
+    assert_eq!(rs.successor0(SUPER_BLOCK_SIZE), SUPER_BLOCK_SIZE + 1);
+    assert_eq!(rs.successor0(SUPER_BLOCK_SIZE - 2), SUPER_BLOCK_SIZE - 1);
+    assert_eq!(rs.successor0(BLOCK_SIZE - 2), BLOCK_SIZE);
+    assert_eq!(rs.successor0(4), 5);
 }

--- a/src/bit_vec/fast_rs_vec/tests.rs
+++ b/src/bit_vec/fast_rs_vec/tests.rs
@@ -1400,19 +1400,19 @@ fn test_predecessor1_and_successor1() {
     bv.flip_bit(SUPER_BLOCK_SIZE + 1);
     let rs = RsVec::from_bit_vec(bv);
 
-    assert_eq!(rs.predecessor1(SUPER_BLOCK_SIZE + 2), SUPER_BLOCK_SIZE + 1);
-    assert_eq!(rs.predecessor1(SUPER_BLOCK_SIZE + 1), SUPER_BLOCK_SIZE);
-    assert_eq!(rs.predecessor1(SUPER_BLOCK_SIZE), SUPER_BLOCK_SIZE - 1);
-    assert_eq!(rs.predecessor1(SUPER_BLOCK_SIZE - 2), BLOCK_SIZE + 1);
+    assert_eq!(rs.predecessor1(SUPER_BLOCK_SIZE + 2), Some(SUPER_BLOCK_SIZE as u64 + 1));
+    assert_eq!(rs.predecessor1(SUPER_BLOCK_SIZE + 1), Some(SUPER_BLOCK_SIZE as u64));
+    assert_eq!(rs.predecessor1(SUPER_BLOCK_SIZE), Some(SUPER_BLOCK_SIZE as u64 - 1));
+    assert_eq!(rs.predecessor1(SUPER_BLOCK_SIZE - 2), Some(BLOCK_SIZE as u64 + 1));
 
-    assert_eq!(rs.predecessor1(4), 3);
+    assert_eq!(rs.predecessor1(4), Some(3));
 
-    assert_eq!(rs.successor1(SUPER_BLOCK_SIZE + 2), rs.len());
-    assert_eq!(rs.successor1(SUPER_BLOCK_SIZE + 1), rs.len());
-    assert_eq!(rs.successor1(SUPER_BLOCK_SIZE), SUPER_BLOCK_SIZE + 1);
-    assert_eq!(rs.successor1(SUPER_BLOCK_SIZE - 2), SUPER_BLOCK_SIZE - 1);
-    assert_eq!(rs.successor1(BLOCK_SIZE - 2), BLOCK_SIZE);
-    assert_eq!(rs.successor1(4), 5);
+    assert_eq!(rs.successor1(SUPER_BLOCK_SIZE + 2), None);
+    assert_eq!(rs.successor1(SUPER_BLOCK_SIZE + 1), None);
+    assert_eq!(rs.successor1(SUPER_BLOCK_SIZE), Some(SUPER_BLOCK_SIZE as u64 + 1));
+    assert_eq!(rs.successor1(SUPER_BLOCK_SIZE - 2), Some(SUPER_BLOCK_SIZE as u64 - 1));
+    assert_eq!(rs.successor1(BLOCK_SIZE - 2), Some(BLOCK_SIZE as u64));
+    assert_eq!(rs.successor1(4), Some(5u64));
 }
 
 #[test]
@@ -1428,17 +1428,19 @@ fn test_predecessor0_and_successor0() {
     bv.flip_bit(SUPER_BLOCK_SIZE + 1);
     let rs = RsVec::from_bit_vec(bv);
 
-    assert_eq!(rs.predecessor0(SUPER_BLOCK_SIZE + 2), SUPER_BLOCK_SIZE + 1);
-    assert_eq!(rs.predecessor0(SUPER_BLOCK_SIZE + 1), SUPER_BLOCK_SIZE);
-    assert_eq!(rs.predecessor0(SUPER_BLOCK_SIZE), SUPER_BLOCK_SIZE - 1);
-    assert_eq!(rs.predecessor0(SUPER_BLOCK_SIZE - 2), BLOCK_SIZE + 1);
+    assert_eq!(rs.predecessor0(SUPER_BLOCK_SIZE + 2), Some(SUPER_BLOCK_SIZE as u64 + 1));
+    assert_eq!(rs.predecessor0(SUPER_BLOCK_SIZE + 1), Some(SUPER_BLOCK_SIZE as u64));
+    assert_eq!(rs.predecessor0(SUPER_BLOCK_SIZE), Some(SUPER_BLOCK_SIZE as u64 - 1));
+    assert_eq!(rs.predecessor0(SUPER_BLOCK_SIZE - 2), Some(BLOCK_SIZE as u64 + 1));
 
-    assert_eq!(rs.predecessor0(4), 3);
+    assert_eq!(rs.predecessor0(4), Some(3));
+    assert_eq!(rs.predecessor0(3), Some(1));
 
-    assert_eq!(rs.successor0(SUPER_BLOCK_SIZE + 2), rs.len());
-    assert_eq!(rs.successor0(SUPER_BLOCK_SIZE + 1), rs.len());
-    assert_eq!(rs.successor0(SUPER_BLOCK_SIZE), SUPER_BLOCK_SIZE + 1);
-    assert_eq!(rs.successor0(SUPER_BLOCK_SIZE - 2), SUPER_BLOCK_SIZE - 1);
-    assert_eq!(rs.successor0(BLOCK_SIZE - 2), BLOCK_SIZE);
-    assert_eq!(rs.successor0(4), 5);
+    assert_eq!(rs.successor0(SUPER_BLOCK_SIZE + 2), None);
+    assert_eq!(rs.successor0(SUPER_BLOCK_SIZE + 1), None);
+    assert_eq!(rs.successor0(SUPER_BLOCK_SIZE), Some(SUPER_BLOCK_SIZE as u64 + 1));
+    assert_eq!(rs.successor0(SUPER_BLOCK_SIZE - 2), Some(SUPER_BLOCK_SIZE as u64 - 1));
+    assert_eq!(rs.successor0(BLOCK_SIZE - 2), Some(BLOCK_SIZE as u64));
+    assert_eq!(rs.successor0(4), Some(5));
+    assert_eq!(rs.successor0(3), Some(5));
 }

--- a/src/bit_vec/fast_rs_vec/tests.rs
+++ b/src/bit_vec/fast_rs_vec/tests.rs
@@ -1386,3 +1386,65 @@ fn test_simd_fallback() {
         SUPER_BLOCK_SIZE + 3 * BLOCK_SIZE + 1
     );
 }
+
+#[test]
+fn test_predecessor1_and_successor1() {
+    let mut bv = BitVec::from_zeros(2 * SUPER_BLOCK_SIZE);
+    bv.flip_bit(1);
+    bv.flip_bit(3);
+    bv.flip_bit(5);
+    bv.flip_bit(BLOCK_SIZE);
+    bv.flip_bit(BLOCK_SIZE + 1);
+    bv.flip_bit(SUPER_BLOCK_SIZE - 1);
+    bv.flip_bit(SUPER_BLOCK_SIZE);
+    bv.flip_bit(SUPER_BLOCK_SIZE + 1);
+    let rs = RsVec::from_bit_vec(bv);
+
+    assert_eq!(rs.predecessor1(SUPER_BLOCK_SIZE - 2), BLOCK_SIZE + 1);
+    assert_eq!(rs.successor1(SUPER_BLOCK_SIZE - 2), SUPER_BLOCK_SIZE - 1);
+
+    assert_eq!(rs.predecessor1(4), 3);
+    assert_eq!(rs.successor1(4), 5);
+
+    //let mut iter = rs.iter1();
+    //assert_eq!(iter.next(), Some(1));
+    //assert_eq!(iter.next(), Some(3));
+    //assert_eq!(iter.next(), Some(5));
+    //assert_eq!(iter.next(), Some(BLOCK_SIZE));
+    //assert_eq!(iter.next(), Some(BLOCK_SIZE + 1));
+    //assert_eq!(iter.next(), Some(SUPER_BLOCK_SIZE - 1));
+    //assert_eq!(iter.next(), Some(SUPER_BLOCK_SIZE));
+    //assert_eq!(iter.next(), Some(SUPER_BLOCK_SIZE + 1));
+    //assert_eq!(iter.next(), None);
+}
+
+#[test]
+fn test_predecessor0_and_successor0() {
+    let mut bv = BitVec::from_ones(2 * SUPER_BLOCK_SIZE);
+    bv.flip_bit(1);
+    bv.flip_bit(3);
+    bv.flip_bit(5);
+    bv.flip_bit(BLOCK_SIZE);
+    bv.flip_bit(BLOCK_SIZE + 1);
+    bv.flip_bit(SUPER_BLOCK_SIZE - 1);
+    bv.flip_bit(SUPER_BLOCK_SIZE);
+    bv.flip_bit(SUPER_BLOCK_SIZE + 1);
+    let rs = RsVec::from_bit_vec(bv);
+
+    assert_eq!(rs.predecessor0(SUPER_BLOCK_SIZE - 2), BLOCK_SIZE + 1);
+    assert_eq!(rs.successor0(SUPER_BLOCK_SIZE - 2), SUPER_BLOCK_SIZE - 1);
+
+    assert_eq!(rs.predecessor0(4), 3);
+    assert_eq!(rs.successor0(4), 5);
+
+    //let mut iter = rs.iter0();
+    //assert_eq!(iter.next(), Some(1));
+    //assert_eq!(iter.next(), Some(3));
+    //assert_eq!(iter.next(), Some(5));
+    //assert_eq!(iter.next(), Some(BLOCK_SIZE));
+    //assert_eq!(iter.next(), Some(BLOCK_SIZE + 1));
+    //assert_eq!(iter.next(), Some(SUPER_BLOCK_SIZE - 1));
+    //assert_eq!(iter.next(), Some(SUPER_BLOCK_SIZE));
+    //assert_eq!(iter.next(), Some(SUPER_BLOCK_SIZE + 1));
+    //assert_eq!(iter.next(), None);
+}


### PR DESCRIPTION
Resolves #28 .
This is a pretty simple implementation which is taken mostly from the `iter` module of `RsVec`.
I'm sure there are some optimization opportunities here. For one thing, I checked that we have the right superblock before checking in the rank-blocks since the rank in blocks is relative to the superblock boundary.

Would appreciate some feedback on this!