### PR TITLE
Rename unroll macro to unroll_n to avoid clash with nightly builtin

### DIFF
--- a/src/bit_vec/fast_rs_vec/select.rs
+++ b/src/bit_vec/fast_rs_vec/select.rs
@@ -3,7 +3,7 @@
 use crate::bit_vec::fast_rs_vec::{BLOCK_SIZE, SELECT_BLOCK_SIZE, SUPER_BLOCK_SIZE};
 use crate::bit_vec::WORD_SIZE;
 use crate::util::pdep::Pdep;
-use crate::util::unroll;
+use crate::util::unroll_n;
 
 /// A safety constant for assertions to make sure that the block size doesn't change without
 /// adjusting the code.
@@ -108,7 +108,7 @@ impl super::RsVec {
             "change unroll constant to {}",
             64 - (SUPER_BLOCK_SIZE / BLOCK_SIZE).leading_zeros() - 1
         );
-        unroll!(4,
+        unroll_n!(4,
             |boundary = { (SUPER_BLOCK_SIZE / BLOCK_SIZE) / 2}|
                 // do not use select_unpredictable here, it degrades performance
                 if self.blocks.len() > *block_index + boundary && rank >= self.blocks[*block_index + boundary].zeros as usize {
@@ -133,7 +133,7 @@ impl super::RsVec {
         // we subtract the number of ones in the word from the rank and continue with the next word.
         let mut index_counter = 0;
         debug_assert!(BLOCK_SIZE / WORD_SIZE == 8, "change unroll constant");
-        unroll!(7, |n = {0}| {
+        unroll_n!(7, |n = {0}| {
                     let word = self.data[block_index * BLOCK_SIZE / WORD_SIZE + n];
                     if (word.count_zeros() as usize) <= rank {
                         rank -= word.count_zeros() as usize;
@@ -330,7 +330,7 @@ impl super::RsVec {
             "change unroll constant to {}",
             64 - (SUPER_BLOCK_SIZE / BLOCK_SIZE).leading_zeros() - 1
         );
-        unroll!(4,
+        unroll_n!(4,
             |boundary = { (SUPER_BLOCK_SIZE / BLOCK_SIZE) / 2}|
                 // do not use select_unpredictable here, it degrades performance
                 if self.blocks.len() > *block_index + boundary && rank >= (*block_index + boundary - block_at_super_block) * BLOCK_SIZE - self.blocks[*block_index + boundary].zeros as usize {
@@ -355,7 +355,7 @@ impl super::RsVec {
         // we subtract the number of ones in the word from the rank and continue with the next word.
         let mut index_counter = 0;
         debug_assert!(BLOCK_SIZE / WORD_SIZE == 8, "change unroll constant");
-        unroll!(7, |n = {0}| {
+        unroll_n!(7, |n = {0}| {
             let word = self.data[block_index * BLOCK_SIZE / WORD_SIZE + n];
             if (word.count_ones() as usize) <= rank {
                 rank -= word.count_ones() as usize;

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -9,4 +9,4 @@ pub(crate) use elias_fano_iter::impl_ef_iterator;
 pub(crate) use general_iter::gen_vector_iter_impl;
 pub(crate) use general_iter::impl_into_iterator_impls;
 pub(crate) use general_iter::impl_vector_iterator;
-pub(crate) use unroll::unroll;
+pub(crate) use unroll::unroll_n;

--- a/src/util/unroll.rs
+++ b/src/util/unroll.rs
@@ -2,16 +2,16 @@
 //! because LLVM is sometimes too conservative to do it itself.
 //! We only use it in hyper-optimized code paths like ``rank``.
 
-macro_rules! unroll {
+macro_rules! unroll_n {
     (1, |$i:ident = {$e:expr}| $s:stmt, $inc:expr) => { let mut $i: usize = $e; $s };
-    (2, |$i:ident = {$e:expr}| $s:stmt, $inc:expr) => { unroll!(1, |$i = {$e}| $s, $inc); $inc; $s };
-    (3, |$i:ident = {$e:expr}| $s:stmt, $inc:expr) => { unroll!(2, |$i = {$e}| $s, $inc); $inc; $s };
-    (4, |$i:ident = {$e:expr}| $s:stmt, $inc:expr) => { unroll!(3, |$i = {$e}| $s, $inc); $inc; $s };
-    (5, |$i:ident = {$e:expr}| $s:stmt, $inc:expr) => { unroll!(4, |$i = {$e}| $s, $inc); $inc; $s };
-    (6, |$i:ident = {$e:expr}| $s:stmt, $inc:expr) => { unroll!(5, |$i = {$e}| $s, $inc); $inc; $s };
-    (7, |$i:ident = {$e:expr}| $s:stmt, $inc:expr) => { unroll!(6, |$i = {$e}| $s, $inc); $inc; $s };
-    (8, |$i:ident = {$e:expr}| $s:stmt, $inc:expr) => { unroll!(7, |$i = {$e}| $s, $inc); $inc; $s };
+    (2, |$i:ident = {$e:expr}| $s:stmt, $inc:expr) => { unroll_n!(1, |$i = {$e}| $s, $inc); $inc; $s };
+    (3, |$i:ident = {$e:expr}| $s:stmt, $inc:expr) => { unroll_n!(2, |$i = {$e}| $s, $inc); $inc; $s };
+    (4, |$i:ident = {$e:expr}| $s:stmt, $inc:expr) => { unroll_n!(3, |$i = {$e}| $s, $inc); $inc; $s };
+    (5, |$i:ident = {$e:expr}| $s:stmt, $inc:expr) => { unroll_n!(4, |$i = {$e}| $s, $inc); $inc; $s };
+    (6, |$i:ident = {$e:expr}| $s:stmt, $inc:expr) => { unroll_n!(5, |$i = {$e}| $s, $inc); $inc; $s };
+    (7, |$i:ident = {$e:expr}| $s:stmt, $inc:expr) => { unroll_n!(6, |$i = {$e}| $s, $inc); $inc; $s };
+    (8, |$i:ident = {$e:expr}| $s:stmt, $inc:expr) => { unroll_n!(7, |$i = {$e}| $s, $inc); $inc; $s };
 }
 
 // export the macro to the crate
-pub(crate) use unroll;
+pub(crate) use unroll_n;


### PR DESCRIPTION
Recent nightly rustc adds an unroll builtin attribute, which makes the pub(crate) use unroll; re-export ambiguous (E0659) and breaks the build on nightly. Rename the macro and its uses.

```
error[E0659]: unroll is ambiguous
    --> src/util/unroll.rs:17:16
     |
  17 | pub(crate) use unroll;
     |                ^^^^^^ ambiguous name
     = note: ambiguous because of a name conflict with a builtin attribute
     = note: unroll could refer to a built-in attribute
```

  Nightly added an `unroll` builtin attribute, which now shadows the crate's
  `unroll` macro. Stable still builds fine. Present on `master` and the `dev_2.0*`
  branches.

  Fix: rename the macro (e.g. `unroll` → `unroll_n`), or otherwise disambiguate
  (raw identifier `r#unroll`, or path-qualify the re-export). 